### PR TITLE
Add reference for the source code offer Issue #27 and #11

### DIFF
--- a/_includes/documentation.html
+++ b/_includes/documentation.html
@@ -20,4 +20,9 @@
       {{ locale.documentation_full_documentation }}
     </a>
   </li>
+  <li>
+    <a href="https://en.opensuse.org/Source_code">
+      {{ locale.source_code }}
+    </a>
+  </li>
 </ul>


### PR DESCRIPTION
Relates to poo#76135 and source offer in general
I did want to re-use translated string source_code. Otherwise I'd reference "How to get source code".

