### PR TITLE
Leap 15.3 Beta release day is tomorrow poo#76324

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -4,6 +4,8 @@
   releases:
   - date: '2020-11-04 12:00:00 UTC'
     state: 'Alpha'
+  - date: '2020-03-03 12:00:00 UTC'
+    state: 'Beta'
 - version: 15.2
   order: 5
   releases:


### PR DESCRIPTION
Setting tomorrow as a release day for Beta
The build will be 91.1 https://openqa.opensuse.org/tests/overview?distri=opensuse&version=15.3&build=91.1&groupid=50
15 SP3 Public Beta recieved go as well and will go live today.