### PR TITLE
Leap 15.3 RC date set to 28.4.2021

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -6,6 +6,8 @@
     state: 'Alpha'
   - date: '2021-03-03 12:00:00 UTC'
     state: 'Beta'
+  - date: '2021-04-28 12:00:00 UTC'
+    state: 'RC'
 - version: 15.2
   order: 5
   releases:


### PR DESCRIPTION
* A week after the submission deadline 21.4
* https://en.opensuse.org/openSUSE:Roadmap

Let's merge it once we have a build that looks okay.