### PR TITLE
Use /distribution/leap/15.3/appliances/iso/ for 15.3 live isos

### DIFF
--- a/_data/153.yml
+++ b/_data/153.yml
@@ -148,77 +148,77 @@ downloads:
   - name: x86_64
     types:
     - name: gnome_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.sha256
     - name: kde_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.sha256
     - name: xfce_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.sha256
     - name: rescue_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.sha256
   - name: aarch64
     types:
     - name: gnome_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.sha256
     - name: kde_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.sha256
     - name: xfce_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.sha256
     - name: rescue_cd
-      primary_link: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso
+      primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.meta4
       - name: pick_mirror
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso?mirrorlist
       - name: checksum
-        url: /distribution/leap/15.3/live/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.sha256
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.sha256
 


### PR DESCRIPTION
While /live/ still exists, it's only a redirect which breaks quite often.

Fixes #34

(CC @lkocman)