### PR TITLE
Point to mirrorcache.opensuse.org instead of download.opensuse.org

### DIFF
--- a/_data/151.yml
+++ b/_data/151.yml
@@ -16,9 +16,9 @@ downloads:
       primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.meta4
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso?mirrorlist
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.metalink
       - name: checksum
         url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso.sha256
       - name: torrent_file
@@ -28,9 +28,9 @@ downloads:
       primary_link: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.meta4
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso?mirrorlist
+        url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.metalink
       - name: checksum
         url: /distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-x86_64.iso.sha256
       - name: torrent_file
@@ -45,9 +45,9 @@ downloads:
       primary_link: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2.meta4
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2?mirrorlist
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-kvm-and-xen-Current.qcow2.sha256
     - name: xen_image
@@ -55,9 +55,9 @@ downloads:
       primary_link: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2.meta4
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2?mirrorlist
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2.sha256
     - name: hyperv_image
@@ -65,9 +65,9 @@ downloads:
       primary_link: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.xz.meta4
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.xz?mirrorlist
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.xz.metalink
       - name: checksum
         url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-MS-HyperV-Current.vhdx.zx.sha256
     - name: vmware_image
@@ -75,9 +75,9 @@ downloads:
       primary_link: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz.meta4
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz?mirrorlist
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz.metalink
       - name: checksum
         url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-VMware-Current.vmdk.xz.sha256
     - name: openstack_image
@@ -85,9 +85,9 @@ downloads:
       primary_link: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2.meta4
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2?mirrorlist
+        url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2.sha256
 - name: live_images
@@ -99,27 +99,27 @@ downloads:
       primary_link: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-GNOME-Live-x86_64-Current.iso.sha256
     - name: kde_cd
       primary_link: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-KDE-Live-x86_64-Current.iso.sha256
     - name: rescue_cd
       primary_link: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.1/live/openSUSE-Leap-15.1-Rescue-CD-x86_64-Current.iso.sha256
 - name: ports_images
@@ -132,9 +132,9 @@ downloads:
       primary_link: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-aarch64-Media.iso.sha256
     - name: network_image
@@ -142,9 +142,9 @@ downloads:
       primary_link: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-aarch64-Media.iso.sha256
   - name: ppc64le
@@ -154,9 +154,9 @@ downloads:
       primary_link: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso
       links:
       - name: metalink
-        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.meta4
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.metalink
       - name: checksum
         url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-ppc64le-Media.iso.sha256
     - name: network_image
@@ -164,8 +164,8 @@ downloads:
       primary_link: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso
       links:
       - name: metalink
-        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.meta4
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.metalink
       - name: checksum
         url: /ports/ppc/distribution/leap/15.1/iso/openSUSE-Leap-15.1-NET-ppc64le-Media.iso.sha256

--- a/_data/152.yml
+++ b/_data/152.yml
@@ -16,9 +16,9 @@ downloads:
       primary_link: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso.meta4
+        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso?mirrorlist
+        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso.metalink
       - name: checksum
         url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64.iso.sha256
     - name: network_image
@@ -26,9 +26,9 @@ downloads:
       primary_link: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso.meta4
+        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso?mirrorlist
+        url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso.metalink
       - name: checksum
         url: /distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-x86_64.iso.sha256
 - name: jeos_images
@@ -41,9 +41,9 @@ downloads:
       primary_link: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2.meta4
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2?mirrorlist
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-kvm-and-xen.qcow2.sha256
     - name: hyperv_image
@@ -51,9 +51,9 @@ downloads:
       primary_link: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz.meta4
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz?mirrorlist
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-MS-HyperV.vhdx.xz.sha256
     - name: vmware_image
@@ -61,9 +61,9 @@ downloads:
       primary_link: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz.meta4
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz?mirrorlist
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: checksum
         url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-VMware.vmdk.xz.sha256
     - name: openstack_image
@@ -71,9 +71,9 @@ downloads:
       primary_link: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2.meta4
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2?mirrorlist
+        url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256
 - name: live_images
@@ -85,27 +85,27 @@ downloads:
       primary_link: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-x86_64-Media.iso.sha256
     - name: kde_cd
       primary_link: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-x86_64-Media.iso.sha256
     - name: rescue_cd
       primary_link: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-x86_64-Media.iso.sha256
   - name: aarch64
@@ -114,27 +114,27 @@ downloads:
       primary_link: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-GNOME-Live-aarch64-Media.iso.sha256
     - name: kde_cd
       primary_link: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-KDE-Live-aarch64-Media.iso.sha256
     - name: rescue_cd
       primary_link: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.2/live/openSUSE-Leap-15.2-Rescue-CD-aarch64-Media.iso.sha256
 - name: ports_images
@@ -147,9 +147,9 @@ downloads:
       primary_link: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-aarch64-Media.iso.sha256
     - name: network_image
@@ -157,9 +157,9 @@ downloads:
       primary_link: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso
       links:
       - name: metalink
-        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso.meta4
+        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso?mirrorlist
+        url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso.metalink
       - name: checksum
         url: /ports/aarch64/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-aarch64-Media.iso.sha256
   - name: ppc64le
@@ -169,9 +169,9 @@ downloads:
       primary_link: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso
       links:
       - name: metalink
-        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso.meta4
+        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso.metalink
       - name: checksum
         url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-ppc64le-Media.iso.sha256
     - name: network_image
@@ -179,8 +179,8 @@ downloads:
       primary_link: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso
       links:
       - name: metalink
-        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso.meta4
+        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso?mirrorlist
+        url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso.metalink
       - name: checksum
         url: /ports/ppc/distribution/leap/15.2/iso/openSUSE-Leap-15.2-NET-ppc64le-Media.iso.sha256

--- a/_data/153.yml
+++ b/_data/153.yml
@@ -16,9 +16,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso.sha256
     - name: network_image
@@ -26,9 +26,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso.sha256
   - name: aarch64
@@ -38,9 +38,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-aarch64-Current.iso.sha256
     - name: network_image
@@ -48,9 +48,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-aarch64-Current.iso.sha256
   - name: ppc64le
@@ -60,9 +60,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso.sha256
     - name: network_image
@@ -70,9 +70,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-ppc64le-Current.iso.sha256
   - name: s390x
@@ -82,9 +82,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-s390x-Current.iso.sha256
     - name: network_image
@@ -92,9 +92,9 @@ downloads:
       primary_link: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso.meta4
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso?mirrorlist
+        url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-s390x-Current.iso.sha256
 - name: jeos_images
@@ -107,9 +107,9 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2.meta4
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2?mirrorlist
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-kvm-and-xen.qcow2.sha256
     - name: hyperv_image
@@ -117,9 +117,9 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz.meta4
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz?mirrorlist
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-MS-HyperV.vhdx.xz.sha256
     - name: vmware_image
@@ -127,9 +127,9 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz.meta4
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz?mirrorlist
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-VMware.vmdk.xz.sha256
     - name: openstack_image
@@ -137,9 +137,9 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.meta4
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2?mirrorlist
+        url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256
 - name: live_images
@@ -151,36 +151,36 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-x86_64-Media.iso.sha256
     - name: kde_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-x86_64-Media.iso.sha256
     - name: xfce_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-x86_64-Media.iso.sha256
     - name: rescue_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-x86_64-Media.iso.sha256
   - name: aarch64
@@ -189,36 +189,36 @@ downloads:
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-GNOME-Live-aarch64-Media.iso.sha256
     - name: kde_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-KDE-Live-aarch64-Media.iso.sha256
     - name: xfce_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-XFCE-Live-aarch64-Media.iso.sha256
     - name: rescue_cd
       primary_link: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso
       links:
       - name: metalink
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.meta4
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.metalink
       - name: pick_mirror
-        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso?mirrorlist
+        url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.metalink
       - name: checksum
         url: /distribution/leap/15.3/appliances/iso/openSUSE-Leap-15.3-Rescue-CD-aarch64-Media.iso.sha256
 

--- a/_data/kubic.yml
+++ b/_data/kubic.yml
@@ -13,9 +13,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Kubic-DVD-x86_64-Current.iso.sha256
   - name: aarch64
@@ -25,9 +25,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso?mirrorlist
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Kubic-DVD-aarch64-Current.iso.sha256
   - name: ppc64le
@@ -37,9 +37,9 @@ downloads:
       primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso
       links:
       - name: metalink
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso.meta4
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso?mirrorlist
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso.metalink
       - name: checksum
         url: /ports/ppc/tumbleweed/iso/openSUSE-Kubic-DVD-ppc64le-Current.iso.sha256
 - name: vm_images
@@ -51,9 +51,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-kvm-and-xen.qcow2.sha256
     - name: vmware_image
@@ -61,9 +61,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmdk.xz.sha256
     - name: vmware_vmx_image
@@ -71,9 +71,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-VMware.vmx.sha256
     - name: vagrant_image
@@ -81,9 +81,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-Vagrant.box.sha256
     - name: hyperv_image
@@ -91,9 +91,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-MS-HyperV.vhdx.xz.sha256
   - name: aarch64
@@ -103,9 +103,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-kvm-and-xen.qcow2.sha256
     - name: vagrant_image
@@ -113,9 +113,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Vagrant.box.sha256
 - name: cloud_images
@@ -127,9 +127,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Kubic-kubeadm-OpenStack-Cloud.qcow2.sha256
 - name: hardware_images
@@ -141,9 +141,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-RaspberryPi.raw.xz.sha256
     - name: pine_image
@@ -151,8 +151,8 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Kubic-kubeadm-Pine64.raw.xz.sha256

--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -221,12 +221,6 @@ aarch64: Servidors, ordinadors de sobretaula, portàtils i tauletes de 64 bits a
   UEFI Arm (aarch64)
 ppc64le: Servidors PowerPC, no ordre dels bytes gran-petit (ppc64le)
 s390x: IBM Z i LinuxONE (s390x)
-chrome_warning: "Degut a $change_in_policy a Google Chrome i Chromium, actualment\
-  \ no funciona baixar imatges\nclicant als botons de baixada. Per evitar aquest problema,\
-  \ cliqueu amb el botó dret al botó de baixada\ni feu clic a \"Desa l'enllaç com\
-  \ a...\" per desar la imatge. Es fa un seguiment del motiu d’aquest error\na $bug\
-  \ a GitHub. Si us plau, feu saber als mantenidors que això us afecta.\n"
-chrome_warning_policy: un canvi de política
 Tumbleweed_features:
   plant:
     description: "El Tumbleweed es basa en dècades d’ús, proves i depuració de centenars\

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -202,13 +202,6 @@ desktops_p1: "Der openSUSE Mitwirkungsprozess ermöglicht die Desktop Entwicklun
   \ können.\nWir heben aktiv drei Desktopumgebungen hervor und bieten noch mehr in\
   \ der erweiterten\nSoftwareliste im Installationsprogramm an.\n"
 yast: YaST, die beste Wahl für den ~~erfahrenen~~ Benutzer
-chrome_warning_policy: einer Änderung einer Richtlinie
-chrome_warning: "Aufgrund einer $change_in_policy in Google Chrome and Chromium, können\
-  \ Images derzeit nicht mit den Download-Schaltflächen heruntergeladen werden.\n\
-  Um dieses Problem zu umgehen, machen Sie einen Rechtsklick auf die Download-Schaltflächte\
-  \ und klicken Sie \"Link speichern unter...\", um das Image zu speichern.\nDie Ursache\
-  \ für dieses Problem wird in $bug auf GitHub getrackt, bitte lassen Sie die Maintainer\
-  \ wissen, wenn Sie betroffen sind.\n"
 s390x: IBM Z und LinuxONE (s390x)
 ppc64le: Server mit PowerPC, nicht big-endian (ppc64le)
 aarch64: Desktops, Laptops und Server mit Arm-64-bit und UEFI (aarch64)

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -257,12 +257,6 @@ aarch64: UEFI Arm 64-bit servers, desktops, laptops and boards (aarch64)
 armv7l: UEFI Arm 32-bit servers, desktops, laptops and boards (armv7l)
 ppc64le: PowerPC servers, not big-endian (ppc64le)
 s390x: IBM Z and LinuxONE (s390x)
-chrome_warning: |
-  Due to $change_in_policy in Google Chrome and Chromium, downloading images by clicking the
-  download buttons is currently broken. To circumvent this issue, right click the download
-  button and click "Save link as..." to save the image. The reason for this bug is tracked in
-  $bug on GitHub, please let the maintainers know this affects you.
-chrome_warning_policy: a change in policy
 overview: Overview
 download: Download
 alternative_downloads: Alternative Downloads

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -228,13 +228,6 @@ i686: Serveurs, ordinateurs fixes et portables Intel ou AMD 32-bit (i686)
 aarch64: Serveurs, ordinateurs fixes et portables, cartes UEFI Arm 64-bit (aarch64)
 ppc64le: Serveurs PowerPC « little-endian » (ppc64le)
 s390x: IBM Z et LinuxONE (s390x)
-chrome_warning: "En raison de $change_in_policy dans Google Chrome et Chromium, le\
-  \ téléchargement des images en cliquant sur les boutons de téléchargement\nne fonctionne\
-  \ pas actuellement. Pour contourner ce problème, faites un clic droit sur le bouton\
-  \ de téléchargement et cliquez sur \"Enregistrer le lien sous...\" pour enregistrer\
-  \ l'image. La raison de ce bogue est suivie dans\n$bug sur GitHub, veuillez faire\
-  \ savoir aux mainteneurs que cela vous affecte.\n"
-chrome_warning_policy: un changement de politique
 download: Télécharger
 overview: Aperçu
 requirements_net_desc: Un accès à Internet est utile, et est indispensable pour l'installateur

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -295,10 +295,3 @@ alternative_downloads_desc: Ci sono anche le immagini di $options. Controlla gli
 alternative_downloads: Scaricamenti alternativi
 download: Scarica
 overview: Panoramica
-chrome_warning_policy: un cambio nella politica
-chrome_warning: "A causa di un $change_in_policy in Google Chrome e in Chromium, non\
-  \ è attualmente possibile\nscaricare le immagini facendo clic sul pulsante di scaricamento.\
-  \ Per aggirare questo problema,\nper salvare l'immagine è sufficiente fare clic\
-  \ col tasto destro, scegliendo poi \"Salva collegamento come...\"\nIl motivo di\
-  \ questo bug è tracciato in $bug su GitHub: fai sapere ai mantenitori che rigurda\
-  \ anche te.\n"

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -174,10 +174,6 @@ i686: Intel/AMD 32 ビットプロセッサ (i686, デスクトップ／ラッ�
 aarch64: UEFI ARM 64 ビットプロセッサ (aarch64, サーバ／デスクトップ／ラップトップ／シングルボードコンピュータ)
 ppc64le: PowerPC プロセッサ (ppc64le, 非ビッグエンディアンサーバ)
 s390x: IBM Z および LinuxONE (s390x)
-chrome_warning: "Google Chrome および Chromium 内の $change_in_policy により、これらのブラウザをご利用の場合、\n\
-  ボタンを押してもイメージをダウンロードできない問題が発生しております。この問題を回避するには、\nそれぞれのダウンロードボタンの上でマウスの右ボタンを押して、\
-  \ \"名前を付けてリンク先を保存\" を\n選択してください。この不具合は GitHub 内の $bug で対応を検討中ですので、詳しくはこちらをお読みください。\n"
-chrome_warning_policy: ポリシー変更
 Tumbleweed_features:
   update:
     name: 継続的な更新

--- a/_data/locales/pt_BR.yml
+++ b/_data/locales/pt_BR.yml
@@ -218,12 +218,6 @@ i686: PCs, laptops e servidores Intel ou AMD 32-bits (i686)
 aarch64: PCs, laptops, placas e servidores UEFI ARM 64-bits (aarch64)
 ppc64le: Servidores PowerPC, não big-endian (ppc64le)
 s390x: IBM Z e LinuxONE (s390x)
-chrome_warning: "Devido a uma $change_in_policy do Google Chrome e do Chromium, baixar\
-  \ imagens clicando nos\nbotões de download está com problemas atualmente. Para contornar\
-  \ este problema, clique com o\nbotão direito no botão de download e clique em \"\
-  Salvar link como...\" para salvar a imagem. O motivo\ndeste erro está rastreado\
-  \ como $bug no GitHub, deixe os mantenedores saber que isto afeta você.\n"
-chrome_warning_policy: uma mudança na política
 Tumbleweed_features:
   user:
     name: Simples de usar

--- a/_data/locales/sk.yml
+++ b/_data/locales/sk.yml
@@ -209,12 +209,6 @@ aarch64: 64-bitové servery, stolné a prenosné počítače a jednodoskové po�
   Arm (aarch64)
 ppc64le: Servery PowerPC, nie big-endian (ppc64le)
 s390x: IBM Z a LinuxONE (s390x)
-chrome_warning: "Sťahovanie obrázov kliknutím na tlačidlá sťahovania je momentálne\
-  \ z dôvodu $ change_in_policy\nv prehliadačoch Google Chrome a Chromium nefunkčné.\
-  \ Ak chcete tento problém obísť, kliknite\npravým tlačidlom myši na tlačidlo stiahnutia\
-  \ a kliknutím \"Uložiť odkaz ako...\" obraz uložte. Dôvod\ntejto chyby je sledovaný\
-  \ v $ bug na GitHub, prosím, informujte správcov, že sa vás to týka.\n"
-chrome_warning_policy: zmena politiky
 openstack_ch_image: Hostiteľ kontajnera OpenStack-Cloud
 pine_ch_image: Hostiteľ kontajnera Pine64
 rpi_ch_image: Hostiteľ kontajnera RaspberryPi

--- a/_data/locales/zh-CN.yml
+++ b/_data/locales/zh-CN.yml
@@ -155,9 +155,6 @@ i686: Intel 和 AMD 32 位桌机、笔记本和服务器（i686）
 aarch64: UEFI Arm 64 位服务器、桌机、笔记本和单板机（aarch64）
 ppc64le: PowerPC 服务器，非大端（ppc64le）
 s390x: IBM Z 和 LinuxONE（s390x）
-chrome_warning: "由于 Google Chrome 和 Chromium 的 $change_in_policy，当前无法用点击下载按钮的方式来下载映像。\n\
-  要解决这个问题，右键点击下载按钮然后点击“链接另存为…”来保存映像。可以在\n GitHub 上的 $bug 追踪该问题，请让维护者知悉你是否受到问题影响。\n"
-chrome_warning_policy: 政策更改
 Tumbleweed_features:
   plant:
     description: "Tumbleweed 的建立，基于不想破坏自己工作流程的高级用户、开发者、系统管理员和苛刻的执行者数十年的使用、测试和调试。Tumbleweed\

--- a/_data/locales/zh_TW.yml
+++ b/_data/locales/zh_TW.yml
@@ -190,9 +190,6 @@ alternative_downloads_desc: 我們也提供 $options 映像檔。請查看 $alte
 alternative_downloads: 其他下載
 download: 下載
 overview: 概觀
-chrome_warning_policy: 政策修改
-chrome_warning: "由於 Google Chrome 與 Chromium 的 $change_in_policy，目前無法通過點擊下載按鈕來下載映像檔。要繞過這個問題，請以滑鼠右鍵點擊下載按鈕並點擊\
-  \ \"另存新檔...\" 來儲存映像檔。這個臭蟲的原因正在 GitHub 上追蹤 ($bug)，請讓維護者知道該問題已影響到您。\n"
 s390x: IBM Z 以及 LinuxONE (s390x)
 ppc64le: PowerPC 伺服器，非 big-endian (ppc64le)
 armv7l: UEFI Arm 32 位元伺服器、桌上型電腦、筆記型電腦以及單板電腦 (armv7l)

--- a/_data/microos.yml
+++ b/_data/microos.yml
@@ -13,9 +13,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso.sha256
   - name: aarch64
@@ -25,9 +25,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso?mirrorlist
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-MicroOS-DVD-aarch64-Current.iso.sha256
   - name: ppc64le
@@ -37,9 +37,9 @@ downloads:
       primary_link: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso
       links:
       - name: metalink
-        url: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso.meta4
+        url: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso?mirrorlist
+        url: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso.metalink
       - name: checksum
         url: /ports/ppc/tumbleweed/iso/openSUSE-MicroOS-DVD-ppc64le-Current.iso.sha256
 - name: vm_images
@@ -51,9 +51,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-kvm-and-xen.qcow2.sha256
     - name: kvm_ch_image
@@ -61,9 +61,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2.sha256
     - name: virtualbox_image
@@ -71,9 +71,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz.sha256
     - name: vmware_image
@@ -81,9 +81,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.sha256
     - name: vmware_vmx_image
@@ -91,9 +91,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx.sha256
     - name: vmware_ch_image
@@ -101,9 +101,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.sha256
     - name: vmware_vmx_ch_image
@@ -111,9 +111,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx.sha256
     - name: vagrant_image
@@ -121,9 +121,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-Vagrant.box.sha256
     - name: vagrant_ch_image
@@ -131,9 +131,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-Vagrant.box.sha256
     - name: hyperv_image
@@ -141,9 +141,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-MS-HyperV.vhdx.xz.sha256
     - name: hyperv_ch_image
@@ -151,9 +151,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-MS-HyperV.vhdx.xz.sha256
   - name: aarch64
@@ -163,9 +163,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-kvm-and-xen.qcow2.sha256
     - name: kvm_ch_image
@@ -173,9 +173,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-kvm-and-xen.qcow2.sha256
     - name: vagrant_image
@@ -183,9 +183,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Vagrant.box.sha256
     - name: vagrant_ch_image
@@ -193,9 +193,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Vagrant.box.sha256
 - name: cloud_images
@@ -207,9 +207,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-OpenStack-Cloud.qcow2.sha256
     - name: openstack_ch_image
@@ -217,9 +217,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.sha256
 - name: hardware_images
@@ -231,9 +231,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-RaspberryPi.raw.xz.sha256
     - name: rpi_ch_image
@@ -241,9 +241,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-RaspberryPi.raw.xz.sha256
     - name: pine_image
@@ -251,9 +251,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-Pine64.raw.xz.sha256
     - name: pine_ch_image
@@ -261,9 +261,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz.meta4
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz?mirrorlist
+        url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-Pine64.raw.xz.sha256
   - name: armv7l
@@ -273,8 +273,8 @@ downloads:
       primary_link: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz
       links:
       - name: metalink
-        url: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz.meta4
+        url: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz.metalink
       - name: pick_mirror
-        url: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz?mirrorlist
+        url: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz.metalink
       - name: checksum
         url: /ports/armv7hl/tumbleweed/appliances/openSUSE-MicroOS.armv7l-RaspberryPi2.raw.xz.sha256

--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -14,9 +14,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso.sha256
     - name: network_image
@@ -24,9 +24,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso.sha256
   - name: i686
@@ -36,9 +36,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-DVD-i586-Current.iso.sha256
     - name: network_image
@@ -46,9 +46,9 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.metalink
       - name: pick_mirror
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso?mirrorlist
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-NET-i586-Current.iso.sha256
   - name: aarch64
@@ -58,9 +58,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso?mirrorlist
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-DVD-aarch64-Current.iso.sha256
     - name: network_image
@@ -68,9 +68,9 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso?mirrorlist
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-NET-aarch64-Current.iso.sha256
   - name: ppc64le
@@ -80,9 +80,9 @@ downloads:
       primary_link: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso
       links:
       - name: metalink
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.meta4
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso?mirrorlist
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.metalink
       - name: checksum
         url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64le-Current.iso.sha256
     - name: network_image
@@ -92,7 +92,7 @@ downloads:
       - name: metalink
         url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.meta
       - name: pick_mirror
-        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso?mirrorlist
+        url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.metalink
       - name: checksum
         url: /ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64le-Current.iso.sha256
   - name: s390x
@@ -102,9 +102,9 @@ downloads:
       primary_link: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso
       links:
       - name: metalink
-        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso.meta4
+        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso.metalink
       - name: pick_mirror
-        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso?mirrorlist
+        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso.metalink
       - name: checksum
         url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-DVD-s390x-Current.iso.sha256
     - name: network_image
@@ -114,7 +114,7 @@ downloads:
       - name: metalink
         url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso.meta
       - name: pick_mirror
-        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso?mirrorlist
+        url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso.metalink
       - name: checksum
         url: /ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso.sha256
 - name: jeos_images
@@ -128,9 +128,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-kvm-and-xen.qcow2.sha256
     - name: hyperv_image
@@ -139,9 +139,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-MS-HyperV.vhdx.xz.sha256
     - name: vmware_image
@@ -150,9 +150,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz.meta4
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-VMware.vmdk.xz.sha256
     - name: openstack_image
@@ -161,9 +161,9 @@ downloads:
       primary_link: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2
       links:
       - name: metalink
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2.meta4
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: pick_mirror
-        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2?mirrorlist
+        url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2.metalink
       - name: checksum
         url: /tumbleweed/appliances/openSUSE-Tumbleweed-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256
 - name: live_images
@@ -176,28 +176,28 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso.sha256
     - name: kde_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.sha256
     - name: xfce_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso.sha256
     - name: rescue_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.sha256
   - name: i686
@@ -206,28 +206,28 @@ downloads:
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso.sha256
     - name: kde_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso.sha256
     - name: xfce_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso.sha256
     - name: rescue_cd
       primary_link: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso
       links:
       - name: metalink
-        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.meta4
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.metalink
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.sha256
   - name: aarch64
@@ -236,27 +236,27 @@ downloads:
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso.sha256
     - name: kde_cd
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso.sha256
     - name: xfce_cd
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso.sha256
     - name: rescue_cd
       primary_link: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso
       links:
       - name: metalink
-        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.meta4
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.metalink
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.sha256

--- a/_includes/distribution.html
+++ b/_includes/distribution.html
@@ -85,9 +85,6 @@
   <div class="tab-pane" id="download" role="tabpanel">
     <section class="py-3">
       <div class="container" role="main">
-        {% capture chrome_warning_link %}<a href="https://blog.chromium.org/2020/02/protecting-users-from-insecure.html" target="_blank">{{ locale.chrome_warning_policy }}</a>{% endcapture %}
-        {% capture chrome_warning_bug %}<a href="https://github.com/openSUSE/mirrorbrain/issues/3" target="_blank">openSUSE/mirrorbrain#3</a>{% endcapture %}
-        <p class="alert alert-danger">{{ locale.chrome_warning | replace: '$change_in_policy', chrome_warning_link | replace: '$bug', chrome_warning_bug }}</p>
         {% assign default = distro.downloads | where_exp: "item", "item.display" %}
         {% for tab in default %}
           <div {% if tab.display == 'all' %}{% elsif tab.display %}class="only-{{ tab.display }}" style="display: none"{% endif %}>

--- a/_includes/types.html
+++ b/_includes/types.html
@@ -15,13 +15,13 @@
     {% endif %}
   </h6>
   <div class="btn-group">
-    <a href="https://download.opensuse.org{{type.primary_link}}" class="btn btn-{{ distro.bg-color }} text-{{ distro.fg-color }}">{{ locale.download }}</a>
+    <a href="https://mirrorcache.opensuse.org{{type.primary_link}}?PEDANTIC=1" class="btn btn-{{ distro.bg-color }} text-{{ distro.fg-color }}">{{ locale.download }}</a>
     <button type="button" class="btn btn-{{ distro.bg-color }} text-{{ distro.fg-color }} dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only">Toggle Dropdown</span>
     </button>
     <div class="dropdown-menu dropdown-menu-right">
       {% for link in type.links %}
-      <a href="https://download.opensuse.org{{link.url}}" class="dropdown-item">{{ locale[link.name] }}</a>
+      <a href="https://mirrorcache.opensuse.org{{link.url}}" class="dropdown-item">{{ locale[link.name] }}</a>
       {% endfor %}
     </div>
   </div>


### PR DESCRIPTION
1. Currently download links are broken for 15.3, and there is no easy way to
fix them, (but they should fix on themselves eventually)
2. Mirrorcache is easier to manage in such situations when mirrors need a
rescan of particular folder
3. Mirrorcache has PEDANTIC=1 parameter which will make sure that file is
present on a mirror before actual redirecting
4. Mirrorcache redirects to mirrors that support https, which fixes
https://github.com/openSUSE/mirrorbrain/issues/3
5. So chrome_warning is not needed anymore
6. MirrorCache doesnt support yet .meta4 and ?mirrorlist requests, so they
are temporarily replaced with .metalink