### PR TITLE
Remove chrome_warning

### DIFF
--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -221,12 +221,6 @@ aarch64: Servidors, ordinadors de sobretaula, portàtils i tauletes de 64 bits a
   UEFI Arm (aarch64)
 ppc64le: Servidors PowerPC, no ordre dels bytes gran-petit (ppc64le)
 s390x: IBM Z i LinuxONE (s390x)
-chrome_warning: "Degut a $change_in_policy a Google Chrome i Chromium, actualment\
-  \ no funciona baixar imatges\nclicant als botons de baixada. Per evitar aquest problema,\
-  \ cliqueu amb el botó dret al botó de baixada\ni feu clic a \"Desa l'enllaç com\
-  \ a...\" per desar la imatge. Es fa un seguiment del motiu d’aquest error\na $bug\
-  \ a GitHub. Si us plau, feu saber als mantenidors que això us afecta.\n"
-chrome_warning_policy: un canvi de política
 Tumbleweed_features:
   plant:
     description: "El Tumbleweed es basa en dècades d’ús, proves i depuració de centenars\

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -202,13 +202,6 @@ desktops_p1: "Der openSUSE Mitwirkungsprozess ermöglicht die Desktop Entwicklun
   \ können.\nWir heben aktiv drei Desktopumgebungen hervor und bieten noch mehr in\
   \ der erweiterten\nSoftwareliste im Installationsprogramm an.\n"
 yast: YaST, die beste Wahl für den ~~erfahrenen~~ Benutzer
-chrome_warning_policy: einer Änderung einer Richtlinie
-chrome_warning: "Aufgrund einer $change_in_policy in Google Chrome and Chromium, können\
-  \ Images derzeit nicht mit den Download-Schaltflächen heruntergeladen werden.\n\
-  Um dieses Problem zu umgehen, machen Sie einen Rechtsklick auf die Download-Schaltflächte\
-  \ und klicken Sie \"Link speichern unter...\", um das Image zu speichern.\nDie Ursache\
-  \ für dieses Problem wird in $bug auf GitHub getrackt, bitte lassen Sie die Maintainer\
-  \ wissen, wenn Sie betroffen sind.\n"
 s390x: IBM Z und LinuxONE (s390x)
 ppc64le: Server mit PowerPC, nicht big-endian (ppc64le)
 aarch64: Desktops, Laptops und Server mit Arm-64-bit und UEFI (aarch64)

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -257,12 +257,6 @@ aarch64: UEFI Arm 64-bit servers, desktops, laptops and boards (aarch64)
 armv7l: UEFI Arm 32-bit servers, desktops, laptops and boards (armv7l)
 ppc64le: PowerPC servers, not big-endian (ppc64le)
 s390x: IBM Z and LinuxONE (s390x)
-chrome_warning: |
-  Due to $change_in_policy in Google Chrome and Chromium, downloading images by clicking the
-  download buttons is currently broken. To circumvent this issue, right click the download
-  button and click "Save link as..." to save the image. The reason for this bug is tracked in
-  $bug on GitHub, please let the maintainers know this affects you.
-chrome_warning_policy: a change in policy
 overview: Overview
 download: Download
 alternative_downloads: Alternative Downloads

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -249,12 +249,6 @@ requirements_hdd_swap_info: Espacio de intercambio deshabilitado para que los ku
 requirements_hdd_ssd_info: SSD de alta velocidad de escritura
 armv7l: Servidores UEFI Arm 32-bit, escritorios, portátiles y placas (armv7l)
 requirements_dvd_desc: Una unidad DVD o puerto USB para el medio de instalación
-chrome_warning: "Debido a un $change_in_policy de Google Chrome y Chromium, la descarga\
-  \ de imágenes al hacer clic en los \nbotones de descarga no funciona actualmente.\
-  \ Para evitar este problema, haga clic con el botón derecho \nen el botón de descarga\
-  \ y seleccione «Guardar enlace como...» para guardar la imagen. El motivo de este\
-  \ error \nse rastrea en $bug en GitHub. Por favor, informe a los mantenedores que\
-  \ esto le afecta.\n"
 alternative_downloads_desc: También tenemos imágenes $options. ¡Consulte las $alternative_downloads!
 MicroOS_features:
   idea:
@@ -358,7 +352,6 @@ requirements_net_desc: El acceso a internet es útil y necesario para el instala
   por red
 requirements_net_conn: Conectividad absoluta entre todas las máquinas del clúster
 requirements_net_mac: Nombre de anfitrión y dirección MAC únicos para cada nodo
-chrome_warning_policy: un cambio en la política
 download: Descargar
 alternative_downloads: Descargas alternativas
 overview: Descripción

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -228,13 +228,6 @@ i686: Serveurs, ordinateurs fixes et portables Intel ou AMD 32-bit (i686)
 aarch64: Serveurs, ordinateurs fixes et portables, cartes UEFI Arm 64-bit (aarch64)
 ppc64le: Serveurs PowerPC « little-endian » (ppc64le)
 s390x: IBM Z et LinuxONE (s390x)
-chrome_warning: "En raison de $change_in_policy dans Google Chrome et Chromium, le\
-  \ téléchargement des images en cliquant sur les boutons de téléchargement\nne fonctionne\
-  \ pas actuellement. Pour contourner ce problème, faites un clic droit sur le bouton\
-  \ de téléchargement et cliquez sur \"Enregistrer le lien sous...\" pour enregistrer\
-  \ l'image. La raison de ce bogue est suivie dans\n$bug sur GitHub, veuillez faire\
-  \ savoir aux mainteneurs que cela vous affecte.\n"
-chrome_warning_policy: un changement de politique
 download: Télécharger
 overview: Aperçu
 requirements_net_desc: Un accès à Internet est utile, et est indispensable pour l'installateur

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -295,10 +295,3 @@ alternative_downloads_desc: Ci sono anche le immagini di $options. Controlla gli
 alternative_downloads: Scaricamenti alternativi
 download: Scarica
 overview: Panoramica
-chrome_warning_policy: un cambio nella politica
-chrome_warning: "A causa di un $change_in_policy in Google Chrome e in Chromium, non\
-  \ è attualmente possibile\nscaricare le immagini facendo clic sul pulsante di scaricamento.\
-  \ Per aggirare questo problema,\nper salvare l'immagine è sufficiente fare clic\
-  \ col tasto destro, scegliendo poi \"Salva collegamento come...\"\nIl motivo di\
-  \ questo bug è tracciato in $bug su GitHub: fai sapere ai mantenitori che rigurda\
-  \ anche te.\n"

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -174,10 +174,6 @@ i686: Intel/AMD 32 ビットプロセッサ (i686, デスクトップ／ラッ�
 aarch64: UEFI ARM 64 ビットプロセッサ (aarch64, サーバ／デスクトップ／ラップトップ／シングルボードコンピュータ)
 ppc64le: PowerPC プロセッサ (ppc64le, 非ビッグエンディアンサーバ)
 s390x: IBM Z および LinuxONE (s390x)
-chrome_warning: "Google Chrome および Chromium 内の $change_in_policy により、これらのブラウザをご利用の場合、\n\
-  ボタンを押してもイメージをダウンロードできない問題が発生しております。この問題を回避するには、\nそれぞれのダウンロードボタンの上でマウスの右ボタンを押して、\
-  \ \"名前を付けてリンク先を保存\" を\n選択してください。この不具合は GitHub 内の $bug で対応を検討中ですので、詳しくはこちらをお読みください。\n"
-chrome_warning_policy: ポリシー変更
 Tumbleweed_features:
   update:
     name: 継続的な更新

--- a/_data/locales/pt_BR.yml
+++ b/_data/locales/pt_BR.yml
@@ -218,12 +218,6 @@ i686: PCs, laptops e servidores Intel ou AMD 32-bits (i686)
 aarch64: PCs, laptops, placas e servidores UEFI ARM 64-bits (aarch64)
 ppc64le: Servidores PowerPC, não big-endian (ppc64le)
 s390x: IBM Z e LinuxONE (s390x)
-chrome_warning: "Devido a uma $change_in_policy do Google Chrome e do Chromium, baixar\
-  \ imagens clicando nos\nbotões de download está com problemas atualmente. Para contornar\
-  \ este problema, clique com o\nbotão direito no botão de download e clique em \"\
-  Salvar link como...\" para salvar a imagem. O motivo\ndeste erro está rastreado\
-  \ como $bug no GitHub, deixe os mantenedores saber que isto afeta você.\n"
-chrome_warning_policy: uma mudança na política
 Tumbleweed_features:
   user:
     name: Simples de usar

--- a/_data/locales/sk.yml
+++ b/_data/locales/sk.yml
@@ -209,12 +209,6 @@ aarch64: 64-bitové servery, stolné a prenosné počítače a jednodoskové po�
   Arm (aarch64)
 ppc64le: Servery PowerPC, nie big-endian (ppc64le)
 s390x: IBM Z a LinuxONE (s390x)
-chrome_warning: "Sťahovanie obrázov kliknutím na tlačidlá sťahovania je momentálne\
-  \ z dôvodu $ change_in_policy\nv prehliadačoch Google Chrome a Chromium nefunkčné.\
-  \ Ak chcete tento problém obísť, kliknite\npravým tlačidlom myši na tlačidlo stiahnutia\
-  \ a kliknutím \"Uložiť odkaz ako...\" obraz uložte. Dôvod\ntejto chyby je sledovaný\
-  \ v $ bug na GitHub, prosím, informujte správcov, že sa vás to týka.\n"
-chrome_warning_policy: zmena politiky
 openstack_ch_image: Hostiteľ kontajnera OpenStack-Cloud
 pine_ch_image: Hostiteľ kontajnera Pine64
 rpi_ch_image: Hostiteľ kontajnera RaspberryPi

--- a/_data/locales/zh-CN.yml
+++ b/_data/locales/zh-CN.yml
@@ -155,9 +155,6 @@ i686: Intel 和 AMD 32 位桌机、笔记本和服务器（i686）
 aarch64: UEFI Arm 64 位服务器、桌机、笔记本和单板机（aarch64）
 ppc64le: PowerPC 服务器，非大端（ppc64le）
 s390x: IBM Z 和 LinuxONE（s390x）
-chrome_warning: "由于 Google Chrome 和 Chromium 的 $change_in_policy，当前无法用点击下载按钮的方式来下载映像。\n\
-  要解决这个问题，右键点击下载按钮然后点击“链接另存为…”来保存映像。可以在\n GitHub 上的 $bug 追踪该问题，请让维护者知悉你是否受到问题影响。\n"
-chrome_warning_policy: 政策更改
 Tumbleweed_features:
   plant:
     description: "Tumbleweed 的建立，基于不想破坏自己工作流程的高级用户、开发者、系统管理员和苛刻的执行者数十年的使用、测试和调试。Tumbleweed\

--- a/_data/locales/zh_TW.yml
+++ b/_data/locales/zh_TW.yml
@@ -190,9 +190,6 @@ alternative_downloads_desc: 我們也提供 $options 映像檔。請查看 $alte
 alternative_downloads: 其他下載
 download: 下載
 overview: 概觀
-chrome_warning_policy: 政策修改
-chrome_warning: "由於 Google Chrome 與 Chromium 的 $change_in_policy，目前無法通過點擊下載按鈕來下載映像檔。要繞過這個問題，請以滑鼠右鍵點擊下載按鈕並點擊\
-  \ \"另存新檔...\" 來儲存映像檔。這個臭蟲的原因正在 GitHub 上追蹤 ($bug)，請讓維護者知道該問題已影響到您。\n"
 s390x: IBM Z 以及 LinuxONE (s390x)
 ppc64le: PowerPC 伺服器，非 big-endian (ppc64le)
 armv7l: UEFI Arm 32 位元伺服器、桌上型電腦、筆記型電腦以及單板電腦 (armv7l)

--- a/_includes/distribution.html
+++ b/_includes/distribution.html
@@ -85,9 +85,6 @@
   <div class="tab-pane" id="download" role="tabpanel">
     <section class="py-3">
       <div class="container" role="main">
-        {% capture chrome_warning_link %}<a href="https://blog.chromium.org/2020/02/protecting-users-from-insecure.html" target="_blank">{{ locale.chrome_warning_policy }}</a>{% endcapture %}
-        {% capture chrome_warning_bug %}<a href="https://github.com/openSUSE/mirrorbrain/issues/3" target="_blank">openSUSE/mirrorbrain#3</a>{% endcapture %}
-        <p class="alert alert-danger">{{ locale.chrome_warning | replace: '$change_in_policy', chrome_warning_link | replace: '$bug', chrome_warning_bug }}</p>
         {% assign default = distro.downloads | where_exp: "item", "item.display" %}
         {% for tab in default %}
           <div {% if tab.display == 'all' %}{% elsif tab.display %}class="only-{{ tab.display }}" style="display: none"{% endif %}>


### PR DESCRIPTION
https requests are now properly redirected to a suitable https mirror,
because https requests for images are now handled by MirrorCache