### PR TITLE
Replace IBM Z with IBM zSystems

### DIFF
--- a/_data/locales/ca.yml
+++ b/_data/locales/ca.yml
@@ -214,7 +214,7 @@ i686: Ordinadors de sobretaula, portàtils i servidors amb Intel o AMD de 32 bit
 aarch64: Servidors, ordinadors de sobretaula, portàtils i tauletes de 64 bits amb
   UEFI Arm (aarch64)
 ppc64le: Servidors PowerPC, no ordre dels bytes gran-petit (ppc64le)
-s390x: IBM Z i LinuxONE (s390x)
+s390x: IBM zSystems i LinuxONE (s390x)
 Tumbleweed_features:
   plant:
     description: "El Tumbleweed es basa en dècades d’ús, proves i depuració de centenars\

--- a/_data/locales/cs.yml
+++ b/_data/locales/cs.yml
@@ -198,4 +198,4 @@ i686: 32bitové stolní počítače, notebooky a servery s procesory Intel nebo 
 aarch64: 64bitové servery, stolní počítače, notebooky a jednodeskové počítače UEFI
   Arm (aarch64)
 ppc64le: Servery PowerPC, nepracující v uložení big-endian (ppc64le)
-s390x: IBM Z a LinuxONE (s390x)
+s390x: IBM zSystems a LinuxONE (s390x)

--- a/_data/locales/de.yml
+++ b/_data/locales/de.yml
@@ -200,7 +200,7 @@ desktops_p1: "Der openSUSE Mitwirkungsprozess ermöglicht die Desktop Entwicklun
   \ können.\nWir heben aktiv drei Desktopumgebungen hervor und bieten noch mehr in\
   \ der erweiterten\nSoftwareliste im Installationsprogramm an.\n"
 yast: YaST, die beste Wahl für den ~~erfahrenen~~ Benutzer
-s390x: IBM Z und LinuxONE (s390x)
+s390x: IBM zSystems und LinuxONE (s390x)
 ppc64le: Server mit PowerPC, nicht big-endian (ppc64le)
 aarch64: Desktops, Laptops und Server mit Arm-64-bit und UEFI (aarch64)
 i686: Desktops, Laptops und Server mit Intel- oder AMD-32-bit (i686)

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -261,7 +261,7 @@ i686: Intel or AMD 32-bit desktops, laptops, and servers (i686)
 aarch64: UEFI Arm 64-bit servers, desktops, laptops and boards (aarch64)
 armv7l: UEFI Arm 32-bit servers, desktops, laptops and boards (armv7l)
 ppc64le: PowerPC servers, not big-endian (ppc64le)
-s390x: IBM Z and LinuxONE (s390x)
+s390x: IBM zSystems and LinuxONE (s390x)
 overview: Overview
 download: Download
 alternative_downloads: Alternative Downloads

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -214,7 +214,7 @@ i686: Equipos de escritorio, portátiles y servidores AMD 32-bit (i686)
 aarch64: Servidores UEFI Arm 64-bit, equipos de escritorio, portátiles y tarjetas
   (aarch64)
 ppc64le: Servidores PowerPC, no big-endian (ppc64le)
-s390x: IBM Z y LinuxONE (s390x)
+s390x: IBM zSystems y LinuxONE (s390x)
 iso_image: Imagen ISO
 vmware_vmx_image: VMware VMX
 vmware_vmx_ch_image: Sistema anfitrión de contenedor VMware VMX

--- a/_data/locales/fr.yml
+++ b/_data/locales/fr.yml
@@ -222,7 +222,7 @@ x86_64: Serveurs, ordinateurs fixes et portables Intel ou AMD 64-bit (x86_64)
 i686: Serveurs, ordinateurs fixes et portables Intel ou AMD 32-bit (i686)
 aarch64: Serveurs, ordinateurs fixes et portables, cartes UEFI Arm 64-bit (aarch64)
 ppc64le: Serveurs PowerPC « little-endian » (ppc64le)
-s390x: IBM Z et LinuxONE (s390x)
+s390x: IBM zSystems et LinuxONE (s390x)
 download: Télécharger
 overview: Aperçu
 requirements_net_desc: Un accès à Internet est utile, et est indispensable pour l'installateur

--- a/_data/locales/id.yml
+++ b/_data/locales/id.yml
@@ -205,7 +205,7 @@ x86_64: Destop, laptop, dan peladen Intel atau AMD 64-bit (x86_64)
 i686: Destop, laptop, dan peladen Intel atau AMD 32-bit (i686)
 aarch64: Peladen, destop, laptop dan papan UEFI Arm 64-bit (aarch64)
 ppc64le: Peladen PowerPC, bukan big-endian (ppc64le)
-s390x: IBM Z dan LinuxONE (s390x)
+s390x: IBM zSystems dan LinuxONE (s390x)
 vmware_vmx_image: VMware VMX
 vmware_ch_image: Host Kontainer VMware
 hyperv_ch_image: Host Kontainer MS HyperV

--- a/_data/locales/it.yml
+++ b/_data/locales/it.yml
@@ -153,7 +153,7 @@ view_distro: Vedi $distro_name
 x86_64: Desktop Intel o AMD a 64-bit, computer portatili e server (x86_64)
 i686: Desktop Intel o AMD a 32-bit, computer portatili e server (i686)
 ppc64le: Server PowerPC, non big-endian (ppc64le)
-s390x: IBM Z e LinuxONE (s390x)
+s390x: IBM zSystems e LinuxONE (s390x)
 site_description: Scopri le distribuzioni di openSUSE e scaricale gratuitamente
 metalink: Metalink
 offline_image: Immagine offline

--- a/_data/locales/ja.yml
+++ b/_data/locales/ja.yml
@@ -169,7 +169,7 @@ x86_64: Intel/AMD 64 ビットプロセッサ (x86_64, デスクトップ／ラ�
 i686: Intel/AMD 32 ビットプロセッサ (i686, デスクトップ／ラップトップ／サーバ)
 aarch64: UEFI ARM 64 ビットプロセッサ (aarch64, サーバ／デスクトップ／ラップトップ／シングルボードコンピュータ)
 ppc64le: PowerPC プロセッサ (ppc64le, 非ビッグエンディアンサーバ)
-s390x: IBM Z および LinuxONE (s390x)
+s390x: IBM zSystems および LinuxONE (s390x)
 Tumbleweed_features:
   update:
     name: 継続的な更新

--- a/_data/locales/pl.yml
+++ b/_data/locales/pl.yml
@@ -201,4 +201,4 @@ x86_64: Komputery stacjonarne, laptopy i serwery oparte o Intel lub AMD 64-bit (
 i686: Komputery stacjonarne, laptopy i serwery oparte o Intel lub AMD 32-bit (i686)
 aarch64: Komputery stacjonarne, laptopy i płyty oparte o UEFI Arm 64-bit (aarch64)
 ppc64le: Serwery oparte o PowerPC, nie duży endian (ppc64le)
-s390x: IBM Z i LinuxONE (s390x)
+s390x: IBM zSystems i LinuxONE (s390x)

--- a/_data/locales/pt_BR.yml
+++ b/_data/locales/pt_BR.yml
@@ -211,7 +211,7 @@ x86_64: PCs, laptops e servidores Intel ou AMD 64-bits (x86_64)
 i686: PCs, laptops e servidores Intel ou AMD 32-bits (i686)
 aarch64: PCs, laptops, placas e servidores UEFI ARM 64-bits (aarch64)
 ppc64le: Servidores PowerPC, não big-endian (ppc64le)
-s390x: IBM Z e LinuxONE (s390x)
+s390x: IBM zSystems e LinuxONE (s390x)
 Tumbleweed_features:
   user:
     name: Simples de usar

--- a/_data/locales/ru.yml
+++ b/_data/locales/ru.yml
@@ -295,7 +295,7 @@ MicroOS_features:
       \ уничтожение старого)\n* Простое восстановление\n"
 armv7l: 32-битные UEFI Arm десктопы, ноутбуки, серверы и одноплатные компьютеры (armv7l)
 ppc64le: PowerPC серверы, кроме big-endian (ppc64le)
-s390x: IBM Z и LinuxONE (s390x)
+s390x: IBM zSystems и LinuxONE (s390x)
 Tumbleweed_features:
   update:
     name: Постоянно обновляется

--- a/_data/locales/sk.yml
+++ b/_data/locales/sk.yml
@@ -204,7 +204,7 @@ i686: 32-bitové stolné a prenosné počítače a servery s Intel or AMD (i686)
 aarch64: 64-bitové servery, stolné a prenosné počítače a jednodoskové počítače UEFI
   Arm (aarch64)
 ppc64le: Servery PowerPC, nie big-endian (ppc64le)
-s390x: IBM Z a LinuxONE (s390x)
+s390x: IBM zSystems a LinuxONE (s390x)
 openstack_ch_image: Hostiteľ kontajnera OpenStack-Cloud
 pine_ch_image: Hostiteľ kontajnera Pine64
 rpi_ch_image: Hostiteľ kontajnera RaspberryPi

--- a/_data/locales/sv.yml
+++ b/_data/locales/sv.yml
@@ -107,7 +107,7 @@ aarch64: UEFI Arm 64-bitarsservrar, stationära datorer, bärbara datorer och en
   (aarch64)
 armv7l: UEFI Arm 32-bitarsservrar, stationära datorer, bärbara datorer och enkortsdatorer
   (armv7l)
-s390x: IBM Z och LinuxONE (s390x)
+s390x: IBM zSystems och LinuxONE (s390x)
 overview: Översikt
 download: Ladda ner
 alternative_downloads: Alternativa nedladdningar

--- a/_data/locales/zh-CN.yml
+++ b/_data/locales/zh-CN.yml
@@ -151,7 +151,7 @@ x86_64: Intel 和 AMD 64 位桌机、笔记本和服务器（x86_64）
 i686: Intel 和 AMD 32 位桌机、笔记本和服务器（i686）
 aarch64: UEFI Arm 64 位服务器、桌机、笔记本和单板机（aarch64）
 ppc64le: PowerPC 服务器，非大端（ppc64le）
-s390x: IBM Z 和 LinuxONE（s390x）
+s390x: IBM zSystems 和 LinuxONE（s390x）
 Tumbleweed_features:
   plant:
     description: "Tumbleweed 的建立，基于不想破坏自己工作流程的高级用户、开发者、系统管理员和苛刻的执行者数十年的使用、测试和调试。Tumbleweed\

--- a/_data/locales/zh_TW.yml
+++ b/_data/locales/zh_TW.yml
@@ -186,7 +186,7 @@ alternative_downloads_desc: 我們也提供 $options 映像檔。請查看 $alte
 alternative_downloads: 其他下載
 download: 下載
 overview: 概觀
-s390x: IBM Z 以及 LinuxONE (s390x)
+s390x: IBM zSystems 以及 LinuxONE (s390x)
 ppc64le: PowerPC 伺服器，非 big-endian (ppc64le)
 armv7l: UEFI Arm 32 位元伺服器、桌上型電腦、筆記型電腦以及單板電腦 (armv7l)
 aarch64: UEFI Arm 64 位元伺服器、桌上型電腦、筆記型電腦以及單板電腦 (aarch64)


### PR DESCRIPTION
IBM has changed the name of the s390x architecture because of the Ukraine war. We have to replace IBM Z with IBM zSystems everywhere. 