### PR TITLE
Add missing pick_mirror links for TW Live Images

### DIFF
--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -178,6 +178,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-x86_64-Current.iso.sha256
     - name: kde_cd
@@ -185,6 +187,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-x86_64-Current.iso.sha256
     - name: xfce_cd
@@ -192,6 +196,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-x86_64-Current.iso.sha256
     - name: rescue_cd
@@ -199,6 +205,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-x86_64-Current.iso.sha256
   - name: i686
@@ -208,6 +216,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-i686-Current.iso.sha256
     - name: kde_cd
@@ -215,6 +225,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-i686-Current.iso.sha256
     - name: xfce_cd
@@ -222,6 +234,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-i686-Current.iso.sha256
     - name: rescue_cd
@@ -229,6 +243,8 @@ downloads:
       links:
       - name: metalink
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.meta4
+      - name: pick_mirror
+        url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso?mirrorlist
       - name: checksum
         url: /tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-i686-Current.iso.sha256
   - name: aarch64
@@ -238,6 +254,8 @@ downloads:
       links:
       - name: metalink
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso.meta4
+      - name: pick_mirror
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso?mirrorlist
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-GNOME-Live-aarch64-Current.iso.sha256
     - name: kde_cd
@@ -245,6 +263,8 @@ downloads:
       links:
       - name: metalink
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso.meta4
+      - name: pick_mirror
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso?mirrorlist
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-KDE-Live-aarch64-Current.iso.sha256
     - name: xfce_cd
@@ -252,6 +272,8 @@ downloads:
       links:
       - name: metalink
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso.meta4
+      - name: pick_mirror
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso?mirrorlist
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-XFCE-Live-aarch64-Current.iso.sha256
     - name: rescue_cd
@@ -259,5 +281,7 @@ downloads:
       links:
       - name: metalink
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.meta4
+      - name: pick_mirror
+        url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso?mirrorlist
       - name: checksum
         url: /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.sha256


### PR DESCRIPTION
For TW there are missing ability to choose mirror in get-o-o.
I added this.

**Before:** 
![изображение](https://user-images.githubusercontent.com/113530911/196242300-e13f04be-4bc9-4f58-99fb-47ae22665b31.png)

**After:**
![изображение](https://user-images.githubusercontent.com/113530911/196243480-606d4294-1d18-4030-a1f3-e148c30af7e5.png)

