### PR TITLE
Leap Micro 5.4 RC build is out

### DIFF
--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -5,6 +5,8 @@
     state: 'Alpha'
   - date: '2023-03-28 12:00:00 UTC'
     state: 'Beta'
+  - date: '2023-04-20 12:00:00 UTC'
+    state: 'RC'
 
 - version: 5.3
   order: 2


### PR DESCRIPTION
Bump to RC with Build24.2, only minor tweaks to EOL date (correction)