### PR TITLE
Leap Micro 5.4 GA, 5.2 is EOL, Leap 15.5 enters RC phase

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -6,6 +6,8 @@
     state: 'Alpha'
   - date: '2023-02-21 12:00:00 UTC'
     state: 'Beta'
+  - date: '2023-04-27 12:00:00 UTC'
+    state: 'RC'
 - version: 15.4
   order: 7
   releases:

--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -7,6 +7,8 @@
     state: 'Beta'
   - date: '2023-04-20 12:00:00 UTC'
     state: 'RC'
+  - date: '2023-04-27 12:00:00 UTC'
+    state: 'Stable'
 
 - version: 5.3
   order: 2
@@ -27,3 +29,5 @@
     state: 'RC'
   - date: '2022-05-18 12:00:00 UTC'
     state: 'Stable'
+  - date: '2023-04-27 12:00:00 UTC'
+    state: 'EOL'


### PR DESCRIPTION
Leap Micro 5.4 GA, 5.2 is EOL, Leap 15.5 enters RC phase

IPRQ approval for Micro was received today (same id as SLEM 5.4).