### PR TITLE
Leap 15.5 marketing availability is at 12:00 UTC 7th June 2023 poo#114208

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -8,6 +8,8 @@
     state: 'Beta'
   - date: '2023-04-27 12:00:00 UTC'
     state: 'RC'
+  - date: '2023-06-07 12:00:00 UTC'
+    state: 'Stable'
 - version: 15.4
   order: 7
   releases:


### PR DESCRIPTION
Leap 15.5 marketing availability is next week on Wednesday. GM is already confirmed, we can publish build any time to make sure mirrors have it synced.

https://progress.opensuse.org/issues/114208