### PR TITLE
Add missing `cloud_images` key in MicroOS page

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -66,6 +66,7 @@ server_aarch64: UEFI Arm 64-bit servers and boards (aarch64)
 server_x86_64: Intel or AMD 64-bit servers (x86_64)
 live_images: Live
 vm_images: Virtual Machine
+cloud_images: Cloud
 cloud_image: Cloud image
 cloud_minimal_desc: Minimal KVM and Xen image with cloud-init
 hardware_images: Hardware


### PR DESCRIPTION
The `cloud_images` key was missing from the English locales of MicroOS's `Download` section in https://get.opensuse.org/microos/. This PR adds the key to make the page render nicely.

**Before (without the key)**

![image](https://github.com/openSUSE/get-o-o/assets/17654553/ba5d6afc-de20-40c8-bb49-7f09e62a9029)

![image](https://github.com/openSUSE/get-o-o/assets/17654553/3822ad36-01a6-4436-b878-3aab8fb828f7)

**After (with the key)**

![image](https://github.com/openSUSE/get-o-o/assets/17654553/b887a6fc-628d-4165-8c26-2c74114bd923)

![image](https://github.com/openSUSE/get-o-o/assets/17654553/1dd33dad-77ad-47cb-960f-62a7b1081141)


