### PR TITLE
Handling for LeapMicro 5.5 raw and qcow image texts

### DIFF
--- a/_data/55.yml
+++ b/_data/55.yml
@@ -50,6 +50,16 @@ downloads:
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz?mirrorlist
       - name: checksum
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.sha256
+    - name: preconfigured_qcow_image
+      desc: kvm_desc
+      primary_link: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2
+      links:
+      - name: metalink
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.meta4
+      - name: pick_mirror
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2?mirrorlist
+      - name: checksum
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.sha256
 
   - name: aarch64
     types:
@@ -83,3 +93,13 @@ downloads:
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz?mirrorlist
       - name: checksum
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.sha256
+    - name: preconfigured_qcow_image
+      desc: kvm_desc
+      primary_link: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2
+      links:
+      - name: metalink
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.meta4
+      - name: pick_mirror
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2?mirrorlist
+      - name: checksum
+        url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.sha256

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -185,8 +185,9 @@ points_welcoming_p1: |
   We try our best to please the community, and we can only make this
   happen when the community is vocal about what they need. That's why we
   ensure contributing is as easy as possible.
-preconfigured_image: Preconfigured Image
-preconfigured_rt_image: Preconfigured RealTime Image
+preconfigured_image: Preconfigured Image (raw)
+preconfigured_qcow_image: Preconfigured Image (qcow)
+preconfigured_rt_image: Preconfigured RealTime Image (raw)
 selfinstall_image: Self-install Image
 selfinstall_rt_image: Self-install RealTime Image
 snapper: System got corrupted? Not a problem anymore


### PR DESCRIPTION
Adding qcow aarch64/x86_64 images.

Any suggestions for description are welcome.
TBH Perhaps we can just skip get-o-o and leave them on download-o-o if somebody needs them.

![diff](https://github.com/openSUSE/get-o-o/assets/510119/77c6bee7-b8be-48ed-ba5b-6b7f884b24ef)

