### PR TITLE
Leap Micro 5.5 is RC

### DIFF
--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -5,6 +5,8 @@
     state: 'Alpha'
   - date: '2023-09-25 12:00:00 UTC'
     state: 'Beta'
+  - date: '2023-10-03 12:00:00 UTC'
+    state: 'RC'
 
 - version: 5.4
   order:  3


### PR DESCRIPTION
let's aim for today 12:00

Roadmap was updated https://en.opensuse.org/openSUSE:Roadmap#Schedule_for_openSUSE_Leap_Micro_5.5