### PR TITLE
Add Leap Micro to server distros

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -277,6 +277,8 @@ server_leap_p2: Regular release with the benefits of both enterprise-grade engin
 server_microos_p1: For single purpose server applications
 server_microos_p2: Designed to host container workloads with automated administration
   & patching
+server_leapmicro_p1: For developers, professionals and containerized workloads
+server_leapmicro_p2: An ultra-reliable, lightweight and immutable operating system for compute environments like edge, embedded, IoT deployments and others.
 new_version_available: $distro_name is now available for download
 new_version_testing: $distro_name is now available for download and testing
 view_distro: View $distro_name

--- a/server.html
+++ b/server.html
@@ -66,6 +66,26 @@ permalink: /server/
           </div>
         </div>
       </div>
+      <div class="col-md-6 py-2 px-5 py-md-5 bg-leapmicro-tint">
+        <div class="row h-100">
+          <div class="col-auto">
+            <div class="distribution-logo">
+            {% include logos/leapmicro.svg %}
+            </div>
+          </div>
+          <div class="col d-flex flex-column">
+            <div class="mb-md-auto">
+              <h2>Leap Micro</h2>
+              <h6>{{ locale.server_leapmicro_p1 }}</h6>
+              <p>{{ locale.server_leapmicro_p2 }}</p>
+            </div>
+            {% assign leapmicro_version = site.releases.leapmicro[site.releases.leapmicro.current].version %}
+            {% capture distro_name %}Leap Micro {{ leapmicro_version }}{% endcapture %}
+            <a href="{{ '/leapmicro/' | append: leapmicro_version | append: '/?type=server' | prefix_locale }}" class="btn btn-light mb-2">{{ locale.learn_more }}</a>
+            <a href="{{ '/leapmicro/' | append: leapmicro_version | append: '/?type=server#download' | prefix_locale }}" class="btn btn-light">{{ locale.download }}</a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Possibly fixes #101 
Big disclaimer: I didn't actually get the Ruby environment to work, so this is entirely untested

But since Leap Micro has been missing from the distros in the server overview for quite some while, I thought I'd try anyway. I basically just copied the Leap section of server.html and replaced all mentions of leap with leapmicro and added some descriptions to locale that are mostly pulled from recent openSUSE news articles about Leap Micro.

Maybe a maintainer is willing to test it to see if it works, maybe someone else interested in working on it can use it as a starting point, or maybe it's just gonna get rejected outright, which is also fine with me. Was just a bit bugged Leap Micro still isn't on there and thought I'd try doing what I can with it.