### PR TITLE
fix: wrong primary_link for a leap micro aarch64 image

### DIFF
--- a/_data/55.yml
+++ b/_data/55.yml
@@ -95,7 +95,7 @@ downloads:
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.sha256
     - name: preconfigured_qcow_image
       desc: kvm_desc
-      primary_link: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2
+      primary_link: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2
       links:
       - name: metalink
         url: /distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.meta4


### PR DESCRIPTION
The primary_link for the aarch64 preconfigured_qcow_image was linked to an x86_64 image.
This pull request changes that line to the correct aarch64 image.

Closes: #177 