### PR TITLE
Leap 15.6 Availability tomorrow at usual time

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -4,6 +4,8 @@
   releases:
   - date: '2023-08-18 12:00:00 UTC'
     state: 'Alpha'
+  - date: '2024-03-07 12:00:00 UTC'
+    state: 'Beta'
 - version: 15.5
   order: 8
   releases:


### PR DESCRIPTION
* Live event at 21:00 CET at https://calendar.opensuse.org/teams/marketing/events/thursday_weekly_meeting