### PR TITLE
Update copyright year for EN locale.

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -1,7 +1,7 @@
 site_title: Get openSUSE
 site_title_short: Get
 site_description: Learn about the openSUSE distributions and download them for free
-site_copyright: © 2023 openSUSE contributors
+site_copyright: © 2024 openSUSE contributors
 search: Search
 translate: Translate
 source_code: Source Code


### PR DESCRIPTION
Changed the EN translation for `site_copyright` from `© 2023 openSUSE contributors` to `© 2024 openSUSE contributors`.