### PR TITLE
Leap Micro 6.0 Beta

### DIFF
--- a/_data/60.yml
+++ b/_data/60.yml
@@ -1,4 +1,3 @@
----
 name: Leap Micro
 version: 6.0
 bg-color: leapmicro
@@ -13,99 +12,96 @@ downloads:
     types:
     - name: selfinstall_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso"
+      primary_link: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso.meta4"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.x86_64-Default-SelfInstall.iso.sha256
     - name: preconfigured_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz"
+      primary_link: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.meta4"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default.raw.xz.sha256
     - name: preconfigured_qcow_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2"
+      primary_link: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.meta4"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2.sha256
+    - name: vmware_image
+      desc: kvm_desc
+      primary_link: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-VMware.vmdk
+      links:
+      - name: metalink
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-VMware.vmdk.meta4
+      - name: pick_mirror
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-VMware.vmdk?mirrorlist
+      - name: checksum
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.x86_64-Default-VMware.vmdk.sha256
     - name: packages_image
       desc: packages_image_desc
-      primary_link: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-x86_64-Media.iso"
+      primary_link: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-x86_64.iso
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-x86_64-Media.iso.meta4"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-x86_64.iso.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-x86_64-Media.iso?mirrorlist"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-x86_64.iso?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-x86_64-Media.iso.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-x86_64-Media.iso.sha256.asc"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-x86_64.iso.sha256
+    
+
   - name: aarch64
     types:
     - name: selfinstall_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso"
+      primary_link: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso.meta4"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/iso/openSUSE-Leap-Micro.aarch64-Default-SelfInstall.iso.sha256
     - name: preconfigured_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz"
+      primary_link: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.meta4"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default.raw.xz.sha256
     - name: preconfigured_qcow_image
       desc: kvm_desc
-      primary_link: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2"
+      primary_link: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.meta4"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2?mirrorlist"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.sha256.asc"
+        url: /distribution/leap-micro/6.0/appliances/openSUSE-Leap-Micro.aarch64-Default-qcow.qcow2.sha256
     - name: packages_image
       desc: packages_image_desc
-      primary_link: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-aarch64-Media.iso"
+      primary_link: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-aarch64.iso
       links:
       - name: metalink
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-aarch64-Media.iso.meta4"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-aarch64.iso.meta4
       - name: pick_mirror
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-aarch64-Media.iso?mirrorlist"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-aarch64.iso?mirrorlist
       - name: checksum
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-aarch64-Media.iso.sha256"
-      - name: signature
-        url: "/distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-Packages-aarch64-Media.iso.sha256.asc"
+        url: /distribution/leap-micro/6.0/product/iso/openSUSE-Leap-Micro-6.0-aarch64.iso.sha256
+    

--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -3,6 +3,8 @@
   releases:
   - date: '2024-04-12 12:00:00 UTC'
     state: 'Alpha'
+  - date: '2024-06-19 01:00:00 UTC'
+    state: 'Beta'
 
 - version: 5.5
   order:  4


### PR DESCRIPTION
* add updated links for Packages dvd after to match new productcomposer
* Set beta release day to today (Beta build is already on the way)


![image](https://github.com/openSUSE/get-o-o/assets/510119/1a8d16ff-0b18-4dea-b0cb-f734f2cb2fc2)
