### PR TITLE
Fixes link redirection problem of Github

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>
+    
+    Get openSUSE
+  </title>
+  <meta name="description"
+    content="Learn about the openSUSE distributions and download them for free">
+
+  <!-- stylesheet -->
+  <link rel="stylesheet" href="https://static.opensuse.org/chameleon-3.0/dist/css/chameleon.css">
+  <link rel="stylesheet" href="/assets/css/app.css">
+
+  <!-- favicon -->
+  <link rel="shortcut icon" type="image/x-icon" href="https://static.opensuse.org/favicon.ico">
+  <link rel="icon" href="https://static.opensuse.org/favicon-32.png" sizes="32x32">
+  <link rel="icon" href="https://static.opensuse.org/favicon-48.png" sizes="48x48">
+  <link rel="icon" href="https://static.opensuse.org/favicon-64.png" sizes="64x64">
+  <link rel="icon" href="https://static.opensuse.org/favicon-96.png" sizes="96x96">
+  <link rel="icon" href="https://static.opensuse.org/favicon-144.png" sizes="144x144">
+  <link rel="icon" href="https://static.opensuse.org/favicon-192.png" sizes="192x192">
+
+  <!-- apple-touch-icon -->
+  <link rel="apple-touch-icon" href="https://static.opensuse.org/favicon-144.png" sizes="144x144">
+  <link rel="apple-touch-icon" href="https://static.opensuse.org/favicon-192.png" sizes="192x192">
+  <link rel="mask-icon" href="https://static.opensuse.org/mask-icon.svg" color="#73ba25">
+
+  <!-- mobile web app data -->
+  <link href="http://localhost:4000/manifest.json" rel="manifest">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="theme-color" content="#73ba25">
+
+  <!-- open graph meta -->
+  <meta property="og:site_name" content="Get openSUSE">
+  <meta property="og:title" content="Get openSUSE">
+  <meta property="og:description"
+    content="Learn about the openSUSE distributions and download them for free">
+  <meta property=" og:url" content="http://localhost:4000/">
+   
+  <meta property="og:image" content="https://static.opensuse.org/favicon-192.png">
+  
+
+  <!-- twitter meta -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Get openSUSE">
+  
+  <meta name="twitter:url" content="http://localhost:4000/">
+  
+  <meta name="twitter:image" content="https://static.opensuse.org/favicon-192.png">
+  
+
+  <!-- javascript -->
+  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/jquery.slim.js"></script>
+  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/bootstrap.bundle.js"></script>
+  <script defer src="https://static.opensuse.org/chameleon-3.0/dist/js/chameleon.js"></script>
+
+  
+  <!-- Piwik -->
+  <script>
+    var _paq = _paq || [];
+    _paq.push(["trackPageView"]);
+    _paq.push(["enableLinkTracking"]);
+    (function () {
+      var u =
+        ("https:" == document.location.protocol ? "https" : "http") +
+        "://" +
+        "beans.opensuse.org/matomo/";
+      _paq.push(["setTrackerUrl", u + "matomo.php"]);
+      _paq.push(["setSiteId", "64"]);
+      var d = document,
+        g = d.createElement("script"),
+        s = d.getElementsByTagName("script")[0];
+      g.type = "text/javascript";
+      g.defer = true;
+      g.async = true;
+      g.src = u + "piwik.js";
+      s.parentNode.insertBefore(g, s);
+    })();
+  </script>
+  <!-- End Piwik Code -->
+  
+
+  
+
+  <link rel="canonical" href="http://localhost:4000/">
+</head>
+
+<body class="d-flex flex-column">
+
+  <nav class="navbar noprint navbar-expand-md sticky-top">
+
+  <a class="navbar-brand" href="/">
+    <img src="https://static.opensuse.org/favicon.svg" class="d-inline-block align-top" alt="openSUSE" title="openSUSE"
+      width="30" height="30">
+    <span class="navbar-title">Get</span>
+  </a>
+
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-collapse">
+    <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd"
+        d="M2.5 11.5A.5.5 0 0 1 3 11h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 3h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z">
+      </path>
+    </svg>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbar-collapse">
+    <ul class="nav navbar-nav mr-auto flex-md-shrink-0">
+      
+
+      
+
+      <li class="nav-item">
+        <a class="nav-link" href="/leap/">
+          
+          Leap
+        </a>
+      </li>
+      
+
+      
+
+      
+
+      <li class="nav-item">
+        <a class="nav-link" href="/tumbleweed/">
+          
+          Tumbleweed
+        </a>
+      </li>
+      
+
+      
+
+      
+
+      <li class="nav-item">
+        <a class="nav-link" href="/leapmicro/">
+          
+          Leap Micro
+        </a>
+      </li>
+      
+
+      
+
+      
+
+      <li class="nav-item">
+        <a class="nav-link" href="/microos/">
+          
+          MicroOS
+        </a>
+      </li>
+      
+
+      
+
+      
+
+      <!-- Locales Dropdown -->
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="locale-menu-link" role="button" data-toggle="dropdown"
+          aria-haspopup="true" aria-expanded="false">
+          <svg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 512 512'>
+            <line x1='48' y1='112' x2='336' y2='112'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <line x1='192' y1='64' x2='192' y2='112'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <polyline points='272 448 368 224 464 448'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <line x1='301.5' y1='384' x2='434.5' y2='384'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <path d='M281.3,112S257,206,199,277,80,384,80,384'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+            <path d='M256,336s-35-27-72-75-56-85-56-85'
+              style='fill:none;stroke:currentColor;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px' />
+          </svg>
+          English
+        </a>
+        <div class="dropdown-menu" aria-labelledby="cat-menu-link">
+          
+          <a class="dropdown-item" href="/ar/">
+            العربية
+          </a>
+          
+          <a class="dropdown-item" href="/bg/">
+            Български
+          </a>
+          
+          <a class="dropdown-item" href="/ca/">
+            Català
+          </a>
+          
+          <a class="dropdown-item" href="/cs/">
+            Čeština
+          </a>
+          
+          <a class="dropdown-item" href="/da/">
+            Dansk
+          </a>
+          
+          <a class="dropdown-item" href="/de/">
+            Deutsch
+          </a>
+          
+          <a class="dropdown-item" href="/el/">
+            Ελληνικά
+          </a>
+          
+          <a class="dropdown-item" href="/es/">
+            Español
+          </a>
+          
+          <a class="dropdown-item" href="/es_419/">
+            Español latinoamericano
+          </a>
+          
+          <a class="dropdown-item" href="/et/">
+            Eesti
+          </a>
+          
+          <a class="dropdown-item" href="/fa/">
+            فارسی
+          </a>
+          
+          <a class="dropdown-item" href="/fi/">
+            Suomi
+          </a>
+          
+          <a class="dropdown-item" href="/fr/">
+            Français
+          </a>
+          
+          <a class="dropdown-item" href="/gl/">
+            Galego
+          </a>
+          
+          <a class="dropdown-item" href="/hi/">
+            हिन्दी
+          </a>
+          
+          <a class="dropdown-item" href="/hu/">
+            Magyar
+          </a>
+          
+          <a class="dropdown-item" href="/id/">
+            Indonesia
+          </a>
+          
+          <a class="dropdown-item" href="/is/">
+            Íslenska
+          </a>
+          
+          <a class="dropdown-item" href="/it/">
+            Italiano
+          </a>
+          
+          <a class="dropdown-item" href="/ja/">
+            日本語
+          </a>
+          
+          <a class="dropdown-item" href="/kab/">
+            Kabyle
+          </a>
+          
+          <a class="dropdown-item" href="/km/">
+            ខ្មែរ
+          </a>
+          
+          <a class="dropdown-item" href="/ko/">
+            한국어
+          </a>
+          
+          <a class="dropdown-item" href="/lt/">
+            Lietuvių
+          </a>
+          
+          <a class="dropdown-item" href="/nb/">
+            Norsk bokmål
+          </a>
+          
+          <a class="dropdown-item" href="/nl/">
+            Nederlands
+          </a>
+          
+          <a class="dropdown-item" href="/nn/">
+            Norwegian nynorsk
+          </a>
+          
+          <a class="dropdown-item" href="/pl/">
+            Polski
+          </a>
+          
+          <a class="dropdown-item" href="/pt/">
+            Português
+          </a>
+          
+          <a class="dropdown-item" href="/pt_BR/">
+            Português
+          </a>
+          
+          <a class="dropdown-item" href="/pt_PT/">
+            Português europeu
+          </a>
+          
+          <a class="dropdown-item" href="/ro/">
+            Română
+          </a>
+          
+          <a class="dropdown-item" href="/ru/">
+            Русский
+          </a>
+          
+          <a class="dropdown-item" href="/sk/">
+            Slovenčina
+          </a>
+          
+          <a class="dropdown-item" href="/sv/">
+            Svenska
+          </a>
+          
+          <a class="dropdown-item" href="/tr/">
+            Türkçe
+          </a>
+          
+          <a class="dropdown-item" href="/vi/">
+            Tiếng Việt
+          </a>
+          
+          <a class="dropdown-item" href="/th/">
+            ไทย
+          </a>
+          
+          <a class="dropdown-item" href="/tzm/">
+            Central atlas tamazight
+          </a>
+          
+          <a class="dropdown-item" href="/uk/">
+            Українська
+          </a>
+          
+          <a class="dropdown-item" href="/wa/">
+            Walloon
+          </a>
+          
+          <a class="dropdown-item" href="/zh_CN/">
+            简体中文
+          </a>
+          
+          <a class="dropdown-item" href="/zh_HK/">
+            繁體中文
+          </a>
+          
+          <a class="dropdown-item" href="/zh_TW/">
+            繁體中文
+          </a>
+          
+          <div class="dropdown-divider"></div>
+          <a class="dropdown-item" href="https://l10n.opensuse.org/projects/get-o-o/">
+            Translate
+          </a>
+        </div>
+      </li>
+
+      
+
+      
+    </ul>
+
+    
+  </div>
+
+  <button class="navbar-toggler megamenu-toggler" type="button" data-toggle="collapse" data-target="#megamenu"
+    aria-expanded="true">
+    <svg class="bi bi-grid" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd"
+        d="M1 2.5A1.5 1.5 0 0 1 2.5 1h3A1.5 1.5 0 0 1 7 2.5v3A1.5 1.5 0 0 1 5.5 7h-3A1.5 1.5 0 0 1 1 5.5v-3zM2.5 2a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 1h3A1.5 1.5 0 0 1 15 2.5v3A1.5 1.5 0 0 1 13.5 7h-3A1.5 1.5 0 0 1 9 5.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zM1 10.5A1.5 1.5 0 0 1 2.5 9h3A1.5 1.5 0 0 1 7 10.5v3A1.5 1.5 0 0 1 5.5 15h-3A1.5 1.5 0 0 1 1 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3zm6.5.5A1.5 1.5 0 0 1 10.5 9h3a1.5 1.5 0 0 1 1.5 1.5v3a1.5 1.5 0 0 1-1.5 1.5h-3A1.5 1.5 0 0 1 9 13.5v-3zm1.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5h-3z">
+      </path>
+    </svg>
+  </button>
+
+</nav>
+
+<div id="megamenu" class="megamenu collapse"></div>
+
+
+  <main class="page-content flex-fill" aria-label="Content">
+    <link rel="stylesheet" href="/assets/css/software.css">
+<div class="container text-center py-4">
+  <h1 class="display-3">openSUSE Distributions</h1>
+  <p class="lead">For desktop, server, and everything in between</p>
+</div>
+<div class="bg-light">
+  <div class="container">
+    <div class="row">
+      <a href="/desktop/" class="col bg-wallpaper text-white text-center p-5">
+        <div class="p-4 m-auto"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="128" height="128" fill="currentColor"><path d="M4 16h16V5H4v11zm9 2v2h4v2H7v-2h4v-2H2.992A.998.998 0 0 1 2 16.993V4.007C2 3.451 2.455 3 2.992 3h18.016c.548 0 .992.449.992 1.007v12.986c0 .556-.455 1.007-.992 1.007H13z"/></svg>
+</div>
+        <h2>Desktop</h2>
+        <h6>Selection of distributions for desktop use</h6>
+      </a>
+      <a href="/server/" class="col bg-server text-white text-center p-5">
+        <div class="p-4 m-auto"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="128" height="128" fill="currentColor"><path d="M5 11h14V5H5v6zm16-7v16a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1zm-2 9H5v6h14v-6zM7 15h3v2H7v-2zm0-8h3v2H7V7z"/></svg>
+</div>
+        <h2>Server</h2>
+        <h6>Selection of distributions for server use</h6>
+      </a>
+    </div>
+  </div>
+</div>
+<div class="container text-center py-4">
+  <h2 class="m-0">Or go straight to the download pages for the distributions</h2>
+</div>
+<div class="bg-wallpaper">
+  <div class="container">
+    <div class="row">
+      <a href="/tumbleweed/" class="col bg-tumbleweed-tint text-white text-center">
+        <div class="w-50 m-auto"><svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 256 256"><path d="m194.99 69.339c-11.512 0-22.656 3.3066-32.576 8.94-9.6748 5.511-18.125 12.981-25.595 21.187-2.9392 3.1841-5.7559 6.6132-8.5726 10.042-2.6942 3.3066-5.1436 6.7356-7.7153 10.165-1.2246 1.7145-2.5718 3.5515-3.7964 5.266-2.5718 3.5515-5.1436 6.9806-7.9603 10.165-2.6942 2.9392-5.511 5.7559-8.3277 8.5726-7.103 6.9805-14.696 13.471-23.146 18.86-6.6132 4.1638-14.451 8.2052-22.534 8.2052-21.676 0-41.026-17.145-41.026-43.23 0-26.085 18.615-40.291 41.026-40.291 12.981 0 24.371 5.511 35.515 15.063l-6.0008 6.1233 14.573 3.674 14.573 3.674-4.0414-14.451-4.0414-14.451-6.4907 6.7356c-11.389-10.165-25.473-18.37-43.23-18.37-29.024 0-52.905 20.942-52.905 52.905 0 30.616 23.881 52.905 50.701 52.905 11.144 0 21.921-3.3066 31.351-8.94 8.5726-5.0211 16.043-11.634 22.901-18.86 2.3268-2.4493 4.5312-4.8986 6.7356-7.348 2.9392-3.1841 5.6334-6.3682 8.0827-10.042 1.1022-1.592 2.0819-3.1841 3.1841-4.7762 1.9594-2.9392 3.7964-5.8784 5.8784-8.6951 3.9189-5.266 7.9603-10.41 12.247-15.308 7.3479-8.2052 15.676-15.798 25.35-20.942 7.7153-4.1638 16.288-6.3682 25.105-6.3682 30.616 0 47.762 21.309 47.762 48.496 0 25.35-16.41 46.292-44.7 46.292-16.165 0-30.372-4.4088-45.312-17.268l6.9806-8.4501-14.818-2.4493-14.818-2.4493 5.266 14.084 5.266 14.084 5.8784-7.103c14.451 13.104 30.249 21.676 50.823 21.676 34.29 0 56.702-26.085 56.702-58.906-0.12246-34.535-23.268-58.416-58.294-58.416z"/></svg></div>
+        <h4>Tumbleweed</h4>
+      </a>
+      
+      <a href="/leap/" class="col bg-leap-tint text-white text-center">
+        <div class="w-50 m-auto"><?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   fill="currentColor"
+   version="1.1"
+   viewBox="0 0 256 256"
+   id="svg234"
+   sodipodi:docname="leap.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <defs
+     id="defs238" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1796"
+     inkscape:window-height="897"
+     id="namedview236"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="2.2483786"
+     inkscape:cx="236.17449"
+     inkscape:cy="134.75119"
+     inkscape:window-x="241"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg234">
+    <sodipodi:guide
+       position="110.74647,0.70491689"
+       orientation="0,-1"
+       id="guide285" />
+    <sodipodi:guide
+       position="138.76667,219.97404"
+       orientation="0,-1"
+       id="guide287" />
+    <sodipodi:guide
+       position="128.31469,206.40871"
+       orientation="1,0"
+       id="guide289" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata230">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 128,36 a 6.9370185,6.9370185 0 0 0 -4.57885,2.005044 L 47.12206,114.30412 a 6.9370185,6.9370185 0 0 0 0,9.80789 l 76.29909,76.29906 a 6.9370185,6.9370185 0 0 0 9.80788,0 l 76.29909,-76.29906 a 6.9370185,6.9370185 0 0 0 0,-9.80789 L 133.22903,38.005044 A 6.9370185,6.9370185 0 0 0 127.99964,36 Z m 0.32517,16.717363 66.49116,66.491147 -66.49116,66.49117 -66.491168,-66.49117 z M 45.089806,160.82157 v 6.93627 a 6.9362785,6.9362785 0 0 0 2.032242,4.90413 l 76.299082,76.29908 a 6.9370185,6.9370185 0 0 0 9.8079,0 l 76.29909,-76.29908 a 6.9362785,6.9362785 0 0 0 2.03201,-4.90413 6.9362785,6.9362785 0 0 0 0,-0.32514 v -6.61106 h -6.93624 a 6.9362785,6.9362785 0 0 0 -4.90406,2.0321 l -71.39466,71.39465 -71.39465,-71.39465 a 6.9362785,6.9362785 0 0 0 -4.904217,-2.00502 v -0.0271 z"
+</svg>
+</div>
+        <h4>Leap 15.6</h4>
+      </a>
+      
+      
+      
+        <a href="/leapmicro/" class="col bg-leapmicro-tint text-white text-center">
+          <div class="w-50 m-auto"><?xml version="1.0" encoding="UTF-8"?>
+<svg fill="currentColor" version="1.1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <path d="m128 36a8.0007 8.0007 0 0 0-5.6565 2.3438l-77.656 77.655h-36.689a8.0001 8.0001 0 0 0-8 8.0003 8.0001 8.0001 0 0 0 8 8.0003h36.689l77.656 77.655a8.0007 8.0007 0 0 0 11.313 0l77.655-77.655h36.687a8.0001 8.0001 0 0 0 8.0006-8.0003 8.0001 8.0001 0 0 0-8.0006-8.0003h-36.687l-77.655-77.655a8.0007 8.0007 0 0 0-5.6564-2.3438zm0 19.312 68.688 68.688-68.688 68.688-68.688-68.688zm0 36.689a32 32 0 0 0-32 32 32 32 0 0 0 32 32 32 32 0 0 0 32-32 32 32 0 0 0-32-32zm0 16.001a16.001 16.001 0 0 1 16.001 16.001 16.001 16.001 0 0 1-16.001 16.001 16.001 16.001 0 0 1-16.001-16.001 16.001 16.001 0 0 1 16.001-16.001zm-80.001 48a8.0001 8.0001 0 0 0-5.6563 2.3439 8.0001 8.0001 0 0 0 0 11.313l85.656 85.655 85.655-85.655a8.0001 8.0001 0 0 0 0-11.313 8.0001 8.0001 0 0 0-11.313 0l-74.343 74.343-74.343-74.343a8.0001 8.0001 0 0 0-5.6566-2.3439z" stroke-width="2.2858"/>
+</svg>
+</div>
+          <h4>Leap Micro 6.0</h4>
+        </a>
+      
+      
+      <a href="/microos/" class="col bg-microos-tint text-white text-center">
+        <div class="w-50 m-auto"><svg fill="currentColor" version="1.1" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+ <path d="m128.12 48c-41.385 0-75.558 31.654-79.594 72h-40.406a8.0008 8.0008 0 1 0 0 16h40.406c4.0354 40.346 38.209 72 79.594 72 41.385 0 75.558-31.654 79.594-72h40.406a8.0008 8.0008 0 1 0 0-16h-40.406c-4.0354-40.346-38.209-72-79.594-72zm0 16c35.174 0 63.512 28.149 63.938 63.219a8.0008 8.0008 0 0 0 0 1.5312c-0.40914 35.085-28.753 63.25-63.938 63.25-35.174 0-63.512-28.149-63.937-63.219a8.0008 8.0008 0 0 0 0-1.5312c0.40914-35.085 28.753-63.25 63.937-63.25zm0 32c-17.578 0-32 14.422-32 32s14.422 32 32 32 32-14.422 32-32c0-17.578-14.422-32-32-32zm0 16c8.9313 0 16 7.0687 16 16s-7.0687 16-16 16-16-7.0687-16-16 7.0687-16 16-16z"/>
+</svg>
+</div>
+        <h4>MicroOS</h4>
+      </a>
+    </div>
+  </div>
+</div>
+
+  </main>
+
+  <footer class="footer">
+  <div class="container">
+    <div class="d-flex justify-content-between">
+      <div class="footer-copyright">
+        © 2024 openSUSE contributors
+      </div>
+      <div class="list-inline">
+        
+        <a class="list-inline-item" href="https://github.com/openSUSE/get-o-o" target="_blank">
+          Source Code
+        </a>
+        
+        <a class="list-inline-item" href="https://raw.githubusercontent.com/openSUSE/get-o-o/main/LICENSE">
+          License
+        </a>
+        
+      </div>
+    </div>
+  </div>
+</footer>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
closes https://github.com/openSUSE/get-o-o/issues/213

The github source link will now open in new tab. By using the target attribute in HTML I have solved the problem.