### PR TITLE
Do not use xz compression for VMDKs on MicrOS and TW

### DIFF
--- a/_data/microos.yml
+++ b/_data/microos.yml
@@ -113,16 +113,16 @@ downloads:
         url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VirtualBox.vdi.xz.sha256.asc"
     - name: vmware_image
       desc: microos_desc
-      primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz"
+      primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk"
       links:
       - name: metalink
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.meta4"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.meta4"
       - name: pick_mirror
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz?mirrorlist"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk?mirrorlist"
       - name: checksum
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.sha256"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.sha256"
       - name: signature
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz.sha256.asc"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.sha256.asc"
     - name: vmware_vmx_image
       desc: microos_desc
       primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx"
@@ -137,16 +137,16 @@ downloads:
         url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmx.sha256.asc"
     - name: vmware_ch_image
       desc: microos_desc
-      primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz"
+      primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk"
       links:
       - name: metalink
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.meta4"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.meta4"
       - name: pick_mirror
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz?mirrorlist"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk?mirrorlist"
       - name: checksum
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.sha256"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.sha256"
       - name: signature
-        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz.sha256.asc"
+        url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.sha256.asc"
     - name: vmware_vmx_ch_image
       desc: microos_desc
       primary_link: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmx"

--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -208,16 +208,16 @@ downloads:
         url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-MS-HyperV.vhdx.xz.sha256.asc"
     - name: vmware_image
       short: vmware_minimal_desc
-      primary_link: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz"
+      primary_link: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk"
       links:
       - name: metalink
-        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz.meta4"
+        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.meta4"
       - name: pick_mirror
-        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz?mirrorlist"
+        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk?mirrorlist"
       - name: checksum
-        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz.sha256"
+        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.sha256"
       - name: signature
-        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz.sha256.asc"
+        url: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.sha256.asc"
     - name: cloud_image
       short: cloud_minimal_desc
       primary_link: "/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"


### PR DESCRIPTION
* Unblock CI especially for for Leap 16.0 addition
* OBS/downlad-o-o servers vmdk files without the .xz suffix, I suppose somebody changed kiwi image build configuration.

```
Checking image size for /ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso
Start the website tests
The following files are reporting 0 size from the repos:
/tumbleweed/appliances/openSUSE-MicroOS.x86_64-VMware.vmdk.xz
/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-VMware.vmdk.xz
/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-VMware.vmdk.xz
Error: Process completed with exit code 1.
```

Full Error log:
https://github.com/openSUSE/get-o-o/actions/runs/11135620517/job/30946172862?pr=217