### PR TITLE
Leap 16.0 image flavor was changed to Leap

### DIFF
--- a/_data/160.yml
+++ b/_data/160.yml
@@ -14,63 +14,63 @@ downloads:
     types:
     - name: agama_image
       desc: agama_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso"
+      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso.meta4"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso?mirrorlist"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso.sha256"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso.sha256.asc"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.sha256.asc"
 #      - name: torrent_file # Torrents only for GM boo#1231361
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-openSUSE.iso.torrent"
+#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.torrent"
   - name: aarch64
     types:
     - name: agama_image
       desc: agama_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso"
+      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso.meta4"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso?mirrorlist"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso.sha256"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso.sha256.asc"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-openSUSE.iso.torrent"
+#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.torrent"
   - name: ppc64le
     types:
     - name: agama_image
       desc: agama_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso"
+      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso.meta4"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso?mirrorlist"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso.sha256"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso.sha256.asc"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-openSUSE.iso.torrent"
+#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.torrent"
   - name: s390x
     types:
     - name: agama_image
       desc: agama_image
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso"
+      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso.meta4"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso?mirrorlist"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso.sha256"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso.sha256.asc"
+        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-openSUSE.iso.torrent"
+#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.torrent"


### PR DESCRIPTION
Download links were tested
![image](https://github.com/user-attachments/assets/148fdb63-e9be-42a1-95ad-69e98a73466a)

