### PR TITLE
Tumbleweed: Do not link to ppc64 images

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -302,7 +302,6 @@ i686: Intel or AMD 32-bit desktops, laptops, and servers (i686)
 aarch64: UEFI Arm 64-bit servers, desktops, laptops and boards (aarch64)
 armv7l: UEFI Arm 32-bit servers, desktops, laptops and boards (armv7l)
 ppc64le: PowerPC servers, little-endian (ppc64le)
-ppc64: PowerPC servers, big-endian (ppc64)
 s390x: IBM zSystems and LinuxONE (s390x)
 overview: Overview
 download: Download

--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -138,32 +138,6 @@ downloads:
         url: "/ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso.sha256"
       - name: signature
         url: "/ports/zsystems/tumbleweed/iso/openSUSE-Tumbleweed-NET-s390x-Current.iso.sha256.asc"
-  - name: ppc64
-    types:
-    - name: offline_image
-      desc: offline_desc
-      primary_link: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso"
-      links:
-      - name: metalink
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso.meta4"
-      - name: pick_mirror
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso?mirrorlist"
-      - name: checksum
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso.sha256"
-      - name: signature
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-DVD-ppc64-Current.iso.sha256.asc"
-    - name: network_image
-      desc: network_desc
-      primary_link: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso"
-      links:
-      - name: metalink
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso.meta4"
-      - name: pick_mirror
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso?mirrorlist"
-      - name: checksum
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso.sha256"
-      - name: signature
-        url: "/ports/ppc/tumbleweed/iso/openSUSE-Tumbleweed-NET-ppc64-Current.iso.sha256.asc"
 - name: minimal_vm_images
   display: server
   info: minimal_vm_info


### PR DESCRIPTION
These are no longer built.