### PR TITLE
DO NOT MERGE Mark Leap Micro 6.1 as stable

### DIFF
--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -1,6 +1,8 @@
 - version: 6.1
   order:  6
   releases:
+  - date: '2024-12-05 12:00:00 UTC'
+    state: 'Stable'
   - date: '2024-12-04 12:00:00 UTC'
     state: 'RC'
   - date: '2024-11-27 12:00:00 UTC'


### PR DESCRIPTION
Today is the day ;-) Let's release it before first SLE Micro 6.1 maintenance updates get released.

![image](https://github.com/user-attachments/assets/c1b8e7c0-3a93-4971-8829-985ae69eac38)
