### PR TITLE
Simplify leap.svg

### DIFF
--- a/_includes/logos/leap.svg
+++ b/_includes/logos/leap.svg
@@ -1,67 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    fill="currentColor"
    version="1.1"
    viewBox="0 0 256 256"
-   id="svg234"
-   sodipodi:docname="leap.svg"
-   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
-  <defs
-     id="defs238" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1796"
-     inkscape:window-height="897"
-     id="namedview236"
-     showgrid="false"
-     showguides="true"
-     inkscape:guide-bbox="true"
-     inkscape:zoom="2.2483786"
-     inkscape:cx="236.17449"
-     inkscape:cy="134.75119"
-     inkscape:window-x="241"
-     inkscape:window-y="32"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg234">
-    <sodipodi:guide
-       position="110.74647,0.70491689"
-       orientation="0,-1"
-       id="guide285" />
-    <sodipodi:guide
-       position="138.76667,219.97404"
-       orientation="0,-1"
-       id="guide287" />
-    <sodipodi:guide
-       position="128.31469,206.40871"
-       orientation="1,0"
-       id="guide289" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata230">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+   id="svg234">
   <path
      d="m 128,36 a 6.9370185,6.9370185 0 0 0 -4.57885,2.005044 L 47.12206,114.30412 a 6.9370185,6.9370185 0 0 0 0,9.80789 l 76.29909,76.29906 a 6.9370185,6.9370185 0 0 0 9.80788,0 l 76.29909,-76.29906 a 6.9370185,6.9370185 0 0 0 0,-9.80789 L 133.22903,38.005044 A 6.9370185,6.9370185 0 0 0 127.99964,36 Z m 0.32517,16.717363 66.49116,66.491147 -66.49116,66.49117 -66.491168,-66.49117 z M 45.089806,160.82157 v 6.93627 a 6.9362785,6.9362785 0 0 0 2.032242,4.90413 l 76.299082,76.29908 a 6.9370185,6.9370185 0 0 0 9.8079,0 l 76.29909,-76.29908 a 6.9362785,6.9362785 0 0 0 2.03201,-4.90413 6.9362785,6.9362785 0 0 0 0,-0.32514 v -6.61106 h -6.93624 a 6.9362785,6.9362785 0 0 0 -4.90406,2.0321 l -71.39466,71.39465 -71.39465,-71.39465 a 6.9362785,6.9362785 0 0 0 -4.904217,-2.00502 v -0.0271 z"
+     fill="currentColor" />
 </svg>

--- a/assets/images/logos/leap.svg
+++ b/assets/images/logos/leap.svg
@@ -3,50 +3,10 @@
    version="1.1"
    viewBox="0 0 128 128"
    id="svg1"
-   sodipodi:docname="leap.svg"
    width="128"
    height="128"
-   inkscape:export-filename="leap.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#505050"
-     bordercolor="#eeeeee"
-     borderopacity="1"
-     inkscape:showpageshadow="0"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="3.8071755"
-     inkscape:cx="43.99587"
-     inkscape:cy="51.875728"
-     inkscape:window-width="1920"
-     inkscape:window-height="1131"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg1" />
+   xmlns="http://www.w3.org/2000/svg">
   <path
      d="M 64.08412,6.8093653 A 3.7101858,3.7101858 0 0 0 61.635175,7.8817398 L 20.827474,48.689438 a 3.7101858,3.7101858 0 0 0 0,5.24564 L 61.635175,94.74277 a 3.7101858,3.7101858 0 0 0 5.245637,0 L 107.68851,53.935078 a 3.7101858,3.7101858 0 0 0 0,-5.24564 L 66.880812,7.8817398 A 3.7101858,3.7101858 0 0 0 64.083928,6.8093653 Z M 64.258041,15.750457 99.820081,51.312499 64.258037,86.874545 28.695989,51.312499 Z M 19.740546,73.568769 v 3.709791 a 3.7097901,3.7097901 0 0 0 1.086922,2.622917 l 40.807701,40.807703 a 3.7101858,3.7101858 0 0 0 5.245637,0 L 107.68851,79.901477 a 3.7097901,3.7097901 0 0 0 1.0868,-2.622917 3.7097901,3.7097901 0 0 0 0,-0.1739 v -3.535859 h -3.70977 a 3.7097901,3.7097901 0 0 0 -2.62287,1.086852 L 64.258043,112.84028 26.073418,74.655653 a 3.7097901,3.7097901 0 0 0 -2.622965,-1.072371 v -0.01445 z"
-     color="#000000"
-     color-rendering="auto"
-     dominant-baseline="auto"
-     fill="#fbc75d"
-     image-rendering="auto"
-     shape-rendering="auto"
-     solid-color="#000000"
-     stop-color="#000000"
-     style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;isolation:auto;mix-blend-mode:normal;fill:#fbc75d;fill-opacity:1;stroke-width:0.494638"
-     id="path1"
-     inkscape:export-filename="leap.png"
-     inkscape:export-xdpi="429.16888"
-     inkscape:export-ydpi="429.16888" />
+     fill="#fbc75d" />
 </svg>


### PR DESCRIPTION
I checked in chromium and firfox browser, on both phone and laptop, but did not find anything wrong with leap.svg. So I simplified the code by removing namespaces and empty <defs> tag.