### PR TITLE
Add MicroOS OpenStack images

### DIFF
--- a/_data/microos.yml
+++ b/_data/microos.yml
@@ -285,6 +285,32 @@ downloads:
         url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.sha256"
       - name: signature
         url: "/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-OpenStack-Cloud.qcow2.sha256.asc"
+  - name: aarch64
+    types:
+    - name: openstack_image
+      desc: microos_desc
+      primary_link: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2"
+      links:
+      - name: metalink
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2.meta4"
+      - name: pick_mirror
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2?mirrorlist"
+      - name: checksum
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2.sha256"
+      - name: signature
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-OpenStack-Cloud.qcow2.sha256.asc"
+    - name: openstack_ch_image
+      desc: microos_desc
+      primary_link: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-OpenStack-Cloud.qcow2"
+      links:
+      - name: metalink
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-OpenStack-Cloud.qcow2.meta4"
+      - name: pick_mirror
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-OpenStack-Cloud.qcow2?mirrorlist"
+      - name: checksum
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-OpenStack-Cloud.qcow2.sha256"
+      - name: signature
+        url: "/ports/aarch64/tumbleweed/appliances/openSUSE-MicroOS.aarch64-ContainerHost-OpenStack-Cloud.qcow2.sha256.asc"
 - name: hardware_images
   arches:
   - name: aarch64


### PR DESCRIPTION
I noticed these were missing, but they were provided on https://en.opensuse.org/Portal:MicroOS/Downloads, which is linked from https://microos.opensuse.org/.

Here's a screenshot of the changes:

![image](https://github.com/user-attachments/assets/009e1d44-2aea-4ab9-b6c3-fab5ac5fbd2d)
