### PR TITLE
Upgrade to current tumbleweed dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gem 'jekyll'
+gem 'jekyll', '~> 4.4.1'
+gem 'liquid', '~> 4.0.4'
 group :jekyll_plugins do
   gem 'jekyll-locale', git: 'https://github.com/hellcp/jekyll-locale.git', ref: '1a9ba57'
   gem 'jekyll-redirect-from'
@@ -12,3 +13,11 @@ gem 'faraday_middleware'
 gem 'human_size'
 gem 'rake'
 gem 'webrick'
+
+gem "csv", "~> 3.3"
+
+gem "logger", "~> 1.7"
+
+gem "base64", "~> 0.2.0"
+
+gem "bigdecimal", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,8 +21,11 @@ GEM
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
+    csv (3.3.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -58,17 +61,20 @@ GEM
     human_size (1.1.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.1)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -83,14 +89,16 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.10.2)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
+    liquid (4.0.4)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     multipart-post (2.2.3)
     pathutil (0.16.2)
@@ -117,15 +125,20 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64 (~> 0.2.0)
+  bigdecimal (~> 3.1)
+  csv (~> 3.3)
   faraday
   faraday_middleware
   human_size
-  jekyll
+  jekyll (~> 4.4.1)
   jekyll-locale!
   jekyll-redirect-from
   jekyll-theme-opensuse!
+  liquid (~> 4.0.4)
+  logger (~> 1.7)
   rake
   webrick
 
 BUNDLED WITH
-   2.1.4
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@ Website promoting the openSUSE distribution development effort, explaining what 
 
 ## How to build?
 
+Instructions assume openSUSE Tumbleweed base:
+
 ```bash
-bundle install --path vendor/bundle
+bundle config --local path vendor/bundle
+bundle install
 bundle exec rake
 bundle exec jekyll build
 ```
@@ -13,8 +16,11 @@ Resulting site will be in `_site` directory.
 
 ## How to serve locally?
 
+Instructions assume openSUSE Tumbleweed base:
+
 ```bash
-bundle install --path vendor/bundle
+bundle config --local path vendor/bundle
+bundle install
 bundle exec rake
 bundle exec jekyll serve
 ```


### PR DESCRIPTION
When trying to test #248, I had trouble getting the right versions of things. The version of bundler used was newer than Leap 15.6, but older than Tumbleweed, which didn't really make sense to me.

This builds for me on a minimal Tumbleweed install (tested w/ `distrobox` in Aeon).

I'm not sure how the current development process works, but this will require whatever the deploy process is to be updated.