### PR TITLE
Show CPU baseline requirements for SLFO-based products

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -135,6 +135,10 @@ requirements_min: Minimum
 requirements_rec: Recommended
 requirements_cpu: CPU
 requirements_cpu_desc: 2 Ghz dual core processor or better
+requirements_cpu_slfo_x86_64: "For x86_64: microarchitecture level x86-64-v2 or higher"
+requirements_cpu_slfo_x86_64_link: https://en.opensuse.org/X86-64_microarchitecture_levels
+requirements_cpu_slfo_ppc64le: "For ppc64le: POWER9 or higher"
+requirements_cpu_slfo_s390x: "For s390x: z14 or higher"
 requirements_mem: Memory
 requirements_mem_desc: $value physical RAM + additional memory for your workload
 requirements_hdd: Storage

--- a/_includes/download/Leap.html
+++ b/_includes/download/Leap.html
@@ -6,6 +6,13 @@
     <h3 id="recommended-system-requirements">{{ locale.requirements }}</h3>
     <ul>
       <li>{{ locale.requirements_cpu_desc }}</li>
+      {% if distro.version == 16.0 %}
+        <ul>
+          <li><a href="{{ locale.requirements_cpu_slfo_x86_64_link }}">{{ locale.requirements_cpu_slfo_x86_64 }}</a></li>
+          <li>{{ locale.requirements_cpu_slfo_ppc64le }}</li>
+          <li>{{ locale.requirements_cpu_slfo_s390x }}</li>
+        </ul>
+      {% endif %}
       <li>{{ locale.requirements_mem_desc | replace: '$value', '2GB' }}</li>
       <li>{{ locale.requirements_hdd_desc }}</li>
       <li>{{ locale.requirements_dvd_desc }}</li>

--- a/_includes/download/LeapMicro.html
+++ b/_includes/download/LeapMicro.html
@@ -7,6 +7,12 @@
       <div class="col">
         <h4>{{ locale.requirements_min }}</h4>
         <ul class="list-unstyled">
+          <li><b>{{ locale.requirements_cpu }}</b>:</li>
+          <ul>
+            <li><a href="{{ locale.requirements_cpu_slfo_x86_64_link }}">{{ locale.requirements_cpu_slfo_x86_64 }}</a></li>
+            <li>{{ locale.requirements_cpu_slfo_ppc64le }}</li>
+            <li>{{ locale.requirements_cpu_slfo_s390x }}</li>
+          </ul>
           <li><b>{{ locale.requirements_mem }}</b>: {{ locale.requirements_mem_desc | replace: '$value', '1GB' }}</li>
           <li><b>{{ locale.requirements_hdd }}</b>:
             <ul>
@@ -19,6 +25,12 @@
       <div class="col">
         <h4>{{ locale.requirements_rec }}</h4>
         <ul class="list-unstyled">
+          <li><b>{{ locale.requirements_cpu }}</b>:</li>
+          <ul>
+            <li><a href="{{ locale.requirements_cpu_slfo_x86_64_link }}">{{ locale.requirements_cpu_slfo_x86_64 }}</a></li>
+            <li>{{ locale.requirements_cpu_slfo_ppc64le }}</li>
+            <li>{{ locale.requirements_cpu_slfo_s390x }}</li>
+          </ul>
           <li><b>{{ locale.requirements_mem }}</b>: {{ locale.requirements_mem_desc | replace: '$value', '2GB' }}</li>
           <li><b>{{ locale.requirements_hdd }}</b>:
             <ul>


### PR DESCRIPTION
Products based on SLFO 1.x, including Leap 16.0, Leap Micro 6.0, 6.1 and 6.2 raised the baseline CPU requirements from TW/15.x on the following architectures:

* x86_64: x86-64-v2 or higher required
* ppc64le: POWER9 or higher required
* s390x: z14 or higher required

## Leap 16.0
![leap-160-download](https://github.com/user-attachments/assets/1df40f05-24b9-4164-8f20-9b01f3ed7dc4)

## Leap Micro 6.1
![leap-micro-61-download](https://github.com/user-attachments/assets/deb8c6da-8d57-4a73-a314-2cc73d216e9b)


For x86_64, the hyperlink goes to https://en.opensuse.org/X86-64_microarchitecture_levels.

Ideas on how to make it fit better are welcome. I think on Leap Micro at least it is now a bit too crowded, with duplicate information. But unsure on how to make it fit better.