### PR TITLE
New Leap 16.0 online image paths

### DIFF
--- a/_data/160.yml
+++ b/_data/160.yml
@@ -28,18 +28,18 @@ downloads:
 #        url: "/distribution/leap/16.0/offline/Leap-16.0-offline-installer-x86_64.install.iso.torrent"
     - name: network_image
       desc: network_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso"
+      primary_link: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.meta4"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso?mirrorlist"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.sha256"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.sha256.asc"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso.sha256.asc"
 #      - name: torrent_file # Torrents only for GM boo#1231361
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.x86_64-Leap.iso.torrent"
+#        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso.torrent"
   - name: aarch64
     types:
     - name: offline_image
@@ -58,18 +58,18 @@ downloads:
 #        url: "/distribution/leap/16.0/offline/Leap-16.0-offline-installer-aarch64.install.iso.torrent"
     - name: network_image
       desc: network_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso"
+      primary_link: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.meta4"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso?mirrorlist"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.sha256"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.sha256.asc"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.aarch64-Leap.iso.torrent"
+#        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-aarch64.install.iso.torrent"
   - name: ppc64le
     types:
     - name: offline_image
@@ -88,18 +88,18 @@ downloads:
 #        url: "/distribution/leap/16.0/offline/Leap-16.0-offline-installer-ppc64le.install.iso.torrent"
     - name: network_image
       desc: network_desc
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso"
+      primary_link: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.meta4"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso?mirrorlist"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.sha256"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.sha256.asc"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.ppc64le-Leap.iso.torrent"
+#        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-ppc64le.install.iso.torrent"
   - name: s390x
     types:
     - name: offline_image
@@ -118,15 +118,15 @@ downloads:
 #        url: "/distribution/leap/16.0/offline/Leap-16.0-offline-installer-s390x.install.iso.torrent"
     - name: network_image
       desc: network_image
-      primary_link: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso"
+      primary_link: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso"
       links:
       - name: metalink
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.meta4"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso.meta4"
       - name: pick_mirror
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso?mirrorlist"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.sha256"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.sha256.asc"
+        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso.sha256.asc"
 #      - name: torrent_file
-#        url: "/distribution/leap/16.0/installer/iso/agama-installer-Leap.s390x-Leap.iso.torrent"
+#        url: "/distribution/leap/16.0/offline/Leap-16.0-online-installer-s390x.install.iso.torrent"


### PR DESCRIPTION
* Tested locally

New localtion (the offline dir will likely be renamed later)
https://download.opensuse.org/distribution/leap/16.0/offline/Leap-16.0-online-installer-x86_64.install.iso