### PR TITLE
Leap 16.0 RC is today

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -2,6 +2,8 @@
 - version: 16.0
   order: 10
   releases:
+  - date: '2025-08-04 12:00:00 UTC'
+    state: 'RC'
   - date: '2025-04-30 12:00:00 UTC'
     state: 'Beta'
   - date: '2025-01-15 12:00:00 UTC'


### PR DESCRIPTION
<img width="2560" height="1440" alt="Screenshot From 2025-08-04 13-15-53" src="https://github.com/user-attachments/assets/caadac83-1e5f-4e06-9c93-7c480bd5c96d" />
