### PR TITLE
Set GA date for Leap 16.0 to Oct 1st

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -2,6 +2,8 @@
 - version: 16.0
   order: 10
   releases:
+  - date: '2025-10-01 12:00:00 UTC'
+    state: 'Stable'
   - date: '2025-08-04 12:00:00 UTC'
     state: 'RC'
   - date: '2025-04-30 12:00:00 UTC'


### PR DESCRIPTION
Set GA date for Leap 16.0 to Oct 1st 

See you all at https://calendar.opensuse.org/teams/product-schedule/events/leap-16-0-release-event