### PR TITLE
Add OEM images KDE, GNOME for Leap 16.0 and GNOME for TW

### DIFF
--- a/_data/160.yml
+++ b/_data/160.yml
@@ -249,7 +249,7 @@ downloads:
   arches:
   - name: server_x86_64
     types: 
-    - name: oem_image
+    - name: oem_image_gnome
       short: oem_image_desc
       primary_link: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-GNOME.iso"
       links:
@@ -263,7 +263,21 @@ downloads:
         url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-GNOME.iso.sha256.asc"
   #        - name: torrent_file
   #          url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-GNOME.iso.torrent"
-    - name: oem_preconfigured_image
+    - name: oem_image_kde
+      short: oem_image_desc
+      primary_link: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso"
+      links:
+      - name: metalink
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.meta4"
+      - name: pick_mirror
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso?mirrorlist"
+      - name: checksum
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256"
+      - name: signature
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256.asc"
+  #        - name: torrent_file
+  #          url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.torrent"
+    - name: oem_preconfigured_image_gnome
       short: oem_preconfigured_image_desc
       primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-GNOME.raw.xz"
       links:
@@ -277,3 +291,19 @@ downloads:
         url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-GNOME.raw.xz.sha256.asc"
 #        - name: torrent_file
 #          url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-GNOME.raw.xz.torrent"
+
+    - name: oem_preconfigured_image_kde
+      short: oem_preconfigured_image_desc
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz"
+      links:
+      - name: metalink
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.meta4"
+      - name: pick_mirror
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz?mirrorlist"
+      - name: checksum
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.sha256"
+      - name: signature
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.sha256.asc"
+#        - name: torrent_file
+#          url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.torrent"
+

--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -30,9 +30,11 @@ offline_updated_desc: |
   Suitable for installation or upgrade.
 oem_images: OEM Images for Hardware Vendors.
 oem_images_info: Both options install the same system image.<br>Use the RAW file with manual tools (e.g. dd), or the bootable self-install ISO for a guided deployment.
-oem_preconfigured_image: OEM Preconfigured Image (raw)
+oem_preconfigured_image_gnome: OEM Preconfigured Image with GNOME (raw)
+oem_preconfigured_image_kde: OEM Preconfigured Image with KDE(raw)
 oem_preconfigured_image_desc: OEM Images for Hardware Vendors.
-oem_image: OEM Self-install Image (iso)
+oem_image_gnome: OEM Self-install Image with GNOME (iso)
+oem_image_kde: OEM Self-install Image with KDE (iso)
 oem_image_desc: OEM Self-install Image
 network_image: Network Image
 network_desc: |

--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -338,3 +338,38 @@ downloads:
         url: "/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.sha256"
       - name: signature
         url: "/ports/aarch64/tumbleweed/iso/openSUSE-Tumbleweed-Rescue-CD-aarch64-Current.iso.sha256.asc"
+- name: oem_images
+  display: desktop
+  info: oem_images_info
+  arches:
+  - name: server_x86_64
+    types: 
+    - name: oem_image_gnome
+      short: oem_image_desc
+      primary_link: "/tumbleweed/appliances/iso//Tumbleweed-OEM.x86_64-GNOME.iso"
+      links:
+      - name: metalink
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-GNOME.iso.meta4"
+      - name: pick_mirror
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-GNOME.iso?mirrorlist"
+      - name: checksum
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-GNOME.iso.sha256"
+      - name: signature
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-GNOME.iso.sha256.asc"
+  #        - name: torrent_file
+  #          url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-GNOME.iso.torrent"
+
+    - name: oem_preconfigured_image_gnome
+      short: oem_preconfigured_image_desc
+      primary_link: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz"
+      links:
+      - name: metalink
+        url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.meta4"
+      - name: pick_mirror
+        url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz?mirrorlist"
+      - name: checksum
+        url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.sha256"
+      - name: signature
+        url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.sha256.asc"
+#        - name: torrent_file
+#          url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.torrent"


### PR DESCRIPTION
Add both KDE and GNOME flavor to our OEM images. TW has only GNOME.

<img width="2560" height="1358" alt="image" src="https://github.com/user-attachments/assets/722ca37e-f0a9-4cc1-8524-c3c14e8b87c5" />


