### PR TITLE
Update Leap 16.0 appliance links after fix of publisher

### DIFF
--- a/_data/160.yml
+++ b/_data/160.yml
@@ -139,109 +139,109 @@ downloads:
     types:
     - name: kvm_image
       short: kvm_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen.qcow2.sha256.asc"
     - name: hyperv_image
       short: hyperv_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-HyperV.vhdx.xz"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-MS-HyperV.vhdx.xz"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-HyperV.vhdx.xz.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-MS-HyperV.vhdx.xz.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-HyperV.vhdx.xz.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-MS-HyperV.vhdx.xz.sha256.asc"
     - name: encrypted_image
       short: encrypted_image
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen-encrypt.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen-encrypt.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen-encrypt.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen-encrypt.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-and-xen-encrypt.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-kvm-and-xen-encrypt.qcow2.sha256.asc"
     - name: vmware_image
       short: vmware_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64.vmdk"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-VMware.vmdk"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64.vmdk.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-VMware.vmdk.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64.vmdk.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-VMware.vmdk.sha256.asc"
 
   - name: server_aarch64
     types:
     - name: kvm_image
       short: kvm_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm.qcow2.sha256.asc"
     - name: hyperv_image
       short: hyperv_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-HyperV.vhdx.xz"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-MS-HyperV.vhdx.xz"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-HyperV.vhdx.xz.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-MS-HyperV.vhdx.xz.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-HyperV.vhdx.xz.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-MS-HyperV.vhdx.xz.sha256.asc"
     - name: encrypted_image
       short: encrypted_image
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-encrypt.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm-encrypt.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-encrypt.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm-encrypt.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-encrypt.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.aarch64-kvm-encrypt.qcow2.sha256.asc"
     - name: rpi_image
       short: rpi_image
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64.raw.xz"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64-RaspberryPi.raw.xz"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64.raw.xz.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64-RaspberryPi.raw.xz.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64.raw.xz.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-Image.aarch64-RaspberryPi.raw.xz.sha256.asc"
 
   - name: ppc64le
     types:
     - name: kvm_image
       short: kvm_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-qcow2.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-qcow2.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-qcow2.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-qcow2.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-qcow2.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-qcow2.qcow2.sha256.asc"
     - name: preconfigured_image
       short: preconfigured_image_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-raw.raw.xz"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-raw.raw.xz"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-raw.raw.xz.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-raw.raw.xz.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-4096-raw.raw.xz.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.ppc64le-ppc64le-4096-raw.raw.xz.sha256.asc"
 
   - name: s390x
     types:
     - name: kvm_image
       short: kvm_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-kvm.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-kvm.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-kvm.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-kvm.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-kvm.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-kvm.qcow2.sha256.asc"
     - name: cloud_image
       short: cloud_minimal_desc
-      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-Cloud.qcow2"
+      primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2"
       links:
       - name: checksum
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-Cloud.qcow2.sha256"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2.sha256"
       - name: signature
-        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-Cloud.qcow2.sha256.asc"
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.s390x-s390x-Cloud.qcow2.sha256.asc"
 
 - name: oem_images
   display: desktop


### PR DESCRIPTION
* Autobuilld team fixed our weirdly shortened links on Publisher, this PR aligns config with new link names