### PR TITLE
Show consistently KDE OEM image for Both 16.0 and TW

### DIFF
--- a/_data/160.yml
+++ b/_data/160.yml
@@ -263,20 +263,7 @@ downloads:
         url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-GNOME.iso.sha256.asc"
   #        - name: torrent_file
   #          url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-GNOME.iso.torrent"
-    - name: oem_image_kde
-      short: oem_image_desc
-      primary_link: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso"
-      links:
-      - name: metalink
-        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.meta4"
-      - name: pick_mirror
-        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso?mirrorlist"
-      - name: checksum
-        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256"
-      - name: signature
-        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256.asc"
-  #        - name: torrent_file
-  #          url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.torrent"
+
     - name: oem_preconfigured_image_gnome
       short: oem_preconfigured_image_desc
       primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-GNOME.raw.xz"
@@ -292,6 +279,21 @@ downloads:
 #        - name: torrent_file
 #          url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-GNOME.raw.xz.torrent"
 
+    - name: oem_image_kde
+      short: oem_image_desc
+      primary_link: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso"
+      links:
+      - name: metalink
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.meta4"
+      - name: pick_mirror
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso?mirrorlist"
+      - name: checksum
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256"
+      - name: signature
+        url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.sha256.asc"
+  #        - name: torrent_file
+  #          url: "/distribution/leap/16.0/appliances/iso/Leap-16.0-OEM.x86_64-KDE.iso.torrent"
+
     - name: oem_preconfigured_image_kde
       short: oem_preconfigured_image_desc
       primary_link: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz"
@@ -306,4 +308,3 @@ downloads:
         url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.sha256.asc"
 #        - name: torrent_file
 #          url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.torrent"
-

--- a/_data/tumbleweed.yml
+++ b/_data/tumbleweed.yml
@@ -373,3 +373,34 @@ downloads:
         url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.sha256.asc"
 #        - name: torrent_file
 #          url: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-GNOME.raw.xz.torrent"
+
+    - name: oem_image_kde
+      short: oem_image_desc
+      primary_link: "/tumbleweed/appliances/iso//Tumbleweed-OEM.x86_64-KDE.iso"
+      links:
+      - name: metalink
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-KDE.iso.meta4"
+      - name: pick_mirror
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-KDE.iso?mirrorlist"
+      - name: checksum
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-KDE.iso.sha256"
+      - name: signature
+        url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-KDE.iso.sha256.asc"
+  #        - name: torrent_file
+  #          url: "/tumbleweed/appliances/iso/Tumbleweed-OEM.x86_64-KDE.iso.torrent"
+
+    - name: oem_preconfigured_image_kde
+      short: oem_preconfigured_image_desc
+      primary_link: "/tumbleweed/appliances/Tumbleweed-OEM.x86_64-KDE.raw.xz"
+      links:
+      - name: metalink
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.meta4"
+      - name: pick_mirror
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz?mirrorlist"
+      - name: checksum
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.sha256"
+      - name: signature
+        url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.sha256.asc"
+#        - name: torrent_file
+#          url: "/distribution/leap/16.0/appliances/Leap-16.0-OEM.x86_64-KDE.raw.xz.torrent"
+


### PR DESCRIPTION
<img width="2581" height="1367" alt="image" src="https://github.com/user-attachments/assets/ae8be6c7-06b6-48f5-a0f4-660e408b4002" />