### PR TITLE
Remove invalid stable date from Leap Micro 5.5

### DIFF
--- a/_data/leapmicro.yml
+++ b/_data/leapmicro.yml
@@ -47,8 +47,6 @@
     state: 'RC'
   - date: '2023-10-12 12:00:00 UTC'
     state: 'Stable'
-  - date: '2024-11-11 12:00:00 UTC'
-    state: 'Stable'
   - date: '2024-06-25 12:00:00 UTC'
     state: 'EOL'
 


### PR DESCRIPTION
For some reason, there's a new release of LeapMicro 5.5 after the EOL date, which makes the API respond with Leap Micro being stable, but it is actually EOL.

cc @lkocman