### PR TITLE
16.1 images should adopt harvester_cloud_image as well

### DIFF
--- a/_data/161.yml
+++ b/_data/161.yml
@@ -169,7 +169,7 @@ downloads:
         url: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-VM.x86_64-VMware.vmdk.sha256"
       - name: signature
         url: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-VM.x86_64-VMware.vmdk.sha256.asc"
-    - name: cloud_image
+    - name: harvester_cloud_image
       short: cloud_minimal_desc
       primary_link: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-VM.x86_64-Cloud.qcow2"
       links:
@@ -211,7 +211,7 @@ downloads:
         url: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-Image.aarch64-RaspberryPi.raw.xz.sha256"
       - name: signature
         url: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-Image.aarch64-RaspberryPi.raw.xz.sha256.asc"
-    - name: cloud_image
+    - name: harvester_cloud_image
       short: cloud_minimal_desc
       primary_link: "/distribution/leap/16.1/appliances/Leap-16.1-Minimal-VM.aarch64-Cloud.qcow2"
       links:


### PR DESCRIPTION
Missed 16.1 with this change