### PR TITLE
Add Beta release date for version 16.1

### DIFF
--- a/_data/leap.yml
+++ b/_data/leap.yml
@@ -2,6 +2,8 @@
 - version: 16.1
   order: 11
   releases:
+  - date: '2026-06-08 12:00:00 UTC'
+    state: 'Beta'
   - date: '2026-01-01 12:00:00 UTC'
     state: 'Alpha'
 - version: 16.0


### PR DESCRIPTION
Leap 16.1 Beta with build 32.2
https://openqa.opensuse.org/tests/overview?distri=opensuse&version=16.1&build=32.2&groupid=139

