### PR TITLE
Use sha512 for offline+online 16.1 images

### DIFF
--- a/_data/161.yml
+++ b/_data/161.yml
@@ -21,9 +21,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso.sha512.asc"
       - name: torrent_file # Torrents only for GM boo#1231361
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-x86_64.install.iso.torrent"
     - name: network_image
@@ -35,9 +35,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso.sha512.asc"
       - name: torrent_file # Torrents only for GM boo#1231361
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-x86_64.install.iso.torrent"
   - name: aarch64
@@ -51,9 +51,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso.sha512.asc"
       - name: torrent_file # Torrents only for GM boo#1231361
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-aarch64.install.iso.torrent"
     - name: network_image
@@ -65,9 +65,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso.sha512.asc"
       - name: torrent_file
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-aarch64.install.iso.torrent"
   - name: ppc64le
@@ -81,9 +81,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso.sha512.asc"
 #      - name: torrent_file # Torrents only for GM boo#1231361
 #        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-ppc64le.install.iso.torrent"
     - name: network_image
@@ -95,9 +95,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso.sha512.asc"
 #      - name: torrent_file
 #        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-ppc64le.install.iso.torrent"
   - name: s390x
@@ -111,9 +111,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso.sha512.asc"
 #      - name: torrent_file # Torrents only for GM boo#1231361
 #        url: "/distribution/leap/16.1/offline/Leap-16.1-offline-installer-s390x.install.iso.torrent"
     - name: network_image
@@ -125,9 +125,9 @@ downloads:
       - name: pick_mirror
         url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso?mirrorlist"
       - name: checksum
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso.sha256"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso.sha512"
       - name: signature
-        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso.sha256.asc"
+        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso.sha512.asc"
 #      - name: torrent_file
 #        url: "/distribution/leap/16.1/offline/Leap-16.1-online-installer-s390x.install.iso.torrent"
 


### PR DESCRIPTION
Leap 16.1 offline + online images are using sha512. 
I'll align rest of appliances which are still using sha256 in another PR